### PR TITLE
feat: Enhance MentionInput with Auto-Conversion & Bug Fixes

### DIFF
--- a/packages/docs/content/docs/chips.mdx
+++ b/packages/docs/content/docs/chips.mdx
@@ -1,0 +1,115 @@
+---
+title: Chips
+description: Understanding mention chips and their role in the MentionInput component.
+---
+
+import { MentisDemo } from "@/components";
+
+# Mention Chips
+
+Mention chips are the visual representation of selected mentions within the `MentionInput` component. They transform plain text mentions into styled, interactive elements that provide better visual feedback and user experience.
+
+## What are Chips?
+
+Chips are `<span>` elements with the class `mention-chip` that replace text-based mentions in the contentEditable interface. They serve several important purposes:
+
+- **Visual Distinction**: Chips are styled differently from regular text to clearly indicate they represent mentions
+- **Data Storage**: Each chip contains metadata about the mentioned entity via `data-*` attributes
+- **Interactive Elements**: Chips can be navigated with keyboard and provide rich interaction
+- **Content Protection**: Chips are set to `contentEditable="false"` to prevent accidental editing
+
+## Chip Structure
+
+When a mention is selected, it's converted into a chip with this structure:
+
+```html
+<span
+  class="mention-chip"
+  contenteditable="false"
+  data-value="user123"
+  data-label="John Doe"
+>
+  @John Doe
+</span>
+```
+
+### Chip Attributes
+
+| Attribute                 | Purpose                                              | Example        |
+| ------------------------- | ---------------------------------------------------- | -------------- |
+| `class="mention-chip"`    | Identifies the element as a mention chip             | `mention-chip` |
+| `contenteditable="false"` | Prevents editing of the chip content                 | `false`        |
+| `data-value`              | Stores the unique identifier of the mentioned entity | `user123`      |
+| `data-label`              | Stores the display name of the mentioned entity      | `John Doe`     |
+
+## Chip Creation
+
+Chips are created in several scenarios:
+
+### 1. Manual Selection
+
+When a user selects an option from the dropdown, a chip is immediately created:
+
+```tsx
+<MentionInput
+  options={[
+    { label: "Alice", value: "alice" },
+    { label: "Bob", value: "bob" },
+  ]}
+  trigger="@"
+/>
+```
+
+### 2. Auto-Conversion
+
+When `autoConvertMentions` is enabled, text mentions are automatically converted to chips when the user types a space or presses Enter:
+
+```tsx
+<MentionInput autoConvertMentions={true} options={options} trigger="@" />
+```
+
+### 3. Paste Operations
+
+When pasting text containing mentions, the component automatically parses and converts them to chips:
+
+```tsx
+// Pasting "@Alice @Bob" will create chips for both mentions
+```
+
+## Chip Styling
+
+Chips come with default styling:
+
+```css
+.mention-chip {
+  display: inline-block;
+  background: #007bff;
+  color: white;
+  padding: 0px 4px;
+  border-radius: 4px;
+}
+```
+
+## Chip Behavior
+
+### Keyboard Navigation
+
+Chips support full keyboard navigation:
+
+- **Arrow Keys**: Navigate through chips and text
+- **Backspace/Delete**: Remove chips when cursor is adjacent
+  {/* - **Click**: Position cursor before or after the chip */}
+
+### Trigger Character Display
+
+The `keepTriggerOnSelect` prop controls whether the trigger character is included in the chip:
+
+```tsx
+// With keepTriggerOnSelect: true (default)
+<span class="mention-chip">@Alice</span>
+
+// With keepTriggerOnSelect: false
+<span class="mention-chip">Alice</span>
+```
+
+Chips are a fundamental part of the MentionInput component that enhance user experience by providing clear visual feedback and maintaining data integrity for mentions within your application.

--- a/packages/docs/content/docs/meta.json
+++ b/packages/docs/content/docs/meta.json
@@ -8,6 +8,7 @@
     "basic-usage",
     "---Core Concepts---",
     "options",
+    "chips",
     "styling",
     "props",
     "---Accessibility---",

--- a/packages/docs/content/docs/overview.mdx
+++ b/packages/docs/content/docs/overview.mdx
@@ -13,7 +13,7 @@ The `MentionInput` component is an accessible, customizable mention input soluti
 - **Enhanced Navigation**: Full keyboard navigation including arrow key navigation into mention chips
 - **Robust Text Handling**: Advanced mention insertion and parsing with comprehensive clipboard support
 - **Customizable Display**: Option to keep or remove the trigger character on selection (`keepTriggerOnSelect`)
-- **Slot-based Customization**: Comprehensive customization for container, contentEditable, listbox, options, and more via `slotsProps`
+- **Slot-based Customization**: Comprehensive customization for container, contentEditable, modal, options, and more via `slotsProps`
 - **Zero Dependencies**: Lightweight implementation with no external dependencies
 - **Fully Accessible**: Complete ARIA roles and keyboard support for optimal accessibility
 - **Rich Text Support**: Display mentions as styled chips within the contentEditable interface

--- a/packages/docs/content/docs/props.mdx
+++ b/packages/docs/content/docs/props.mdx
@@ -7,14 +7,14 @@ import { MentisDemo } from "@/components";
 
 ## Props
 
-| Name                | Type                    | Required | Description                                                                                     |
-| ------------------- | ----------------------- | -------- | ----------------------------------------------------------------------------------------------- |
-| defaultValue        | string                  | No       | The initial value of the input.                                                                 |
-| options             | MentionOption[]         | Yes      | Array of mentionable options. See [Options](./options) for more.                                |
-| onChange            | (value: string) => void | No       | Callback fired when the input value changes.                                                    |
+| Name                | Type                    | Required | Description                                                                                    |
+| ------------------- | ----------------------- | -------- | ---------------------------------------------------------------------------------------------- |
+| defaultValue        | string                  | No       | The initial value of the input.                                                                |
+| options             | MentionOption[]         | Yes      | Array of mentionable options. See [Options](./options) for more.                               |
+| onChange            | (value: string) => void | No       | Callback fired when the input value changes.                                                   |
 | keepTriggerOnSelect | boolean                 | No       | Whether to keep the trigger character (e.g. '@') when an option is selected. Defaults to true. |
-| trigger             | string                  | No       | The character or string that triggers the mention dropdown. Defaults to '@'.                    |
-| slotsProps          | SlotProps               | No       | Customization for internal component slots (see below).                                         |
+| trigger             | string                  | No       | The character or string that triggers the mention dropdown. Defaults to '@'.                   |
+| slotsProps          | SlotProps               | No       | Customization for internal component slots (see below).                                        |
 
 ### MentionOption
 
@@ -49,7 +49,7 @@ type SlotProps = Partial<{
     | "aria-autocomplete"
     | "aria-expanded"
   >; // Props for the contentEditable element
-  listbox: Omit<React.HTMLAttributes<HTMLDivElement>, "id" | "role" | "style">; // Props for the dropdown listbox
+  modal: Omit<React.HTMLAttributes<HTMLDivElement>, "id" | "role" | "style">; // Props for the dropdown listbox
   option: Omit<
     React.HTMLAttributes<HTMLDivElement>,
     "id" | "key" | "role" | "style" | "aria-selected" | "onMouseDown"
@@ -61,7 +61,7 @@ type SlotProps = Partial<{
 
 - `container`: Props for the outer `<div>` container.
 - `contentEditable`: Props for the contentEditable `<div>` element (excluding controlled props for mention functionality).
-- `listbox`: Props for the dropdown listbox container.
+- `modal`: Props for the dropdown listbox container.
 - `option`: Props for each option in the dropdown.
 - `noOptions`: Props for the 'No items found' message.
 - `highlightedClassName`: Custom class for the currently highlighted option.

--- a/packages/docs/content/docs/props.mdx
+++ b/packages/docs/content/docs/props.mdx
@@ -12,7 +12,7 @@ import { MentisDemo } from "@/components";
 | defaultValue        | string                  | No       | The initial value of the input.                                                                 |
 | options             | MentionOption[]         | Yes      | Array of mentionable options. See [Options](./options) for more.                                |
 | onChange            | (value: string) => void | No       | Callback fired when the input value changes.                                                    |
-| keepTriggerOnSelect | boolean                 | No       | Whether to keep the trigger character (e.g. '@') when an option is selected. Defaults to false. |
+| keepTriggerOnSelect | boolean                 | No       | Whether to keep the trigger character (e.g. '@') when an option is selected. Defaults to true. |
 | trigger             | string                  | No       | The character or string that triggers the mention dropdown. Defaults to '@'.                    |
 | slotsProps          | SlotProps               | No       | Customization for internal component slots (see below).                                         |
 
@@ -70,7 +70,7 @@ type SlotProps = Partial<{
 
 #### `keepTriggerOnSelect`
 
-If `true`, the trigger character (such as `@`) will be kept in the input when an option is selected. If `false` (default), the trigger character will be removed before the selected label.
+If `true` (default), the trigger character (such as `@`) will be kept in the input when an option is selected. If `false`, the trigger character will be removed before the selected label.
 
 ```tsx
 <MentionInput keepTriggerOnSelect ... />

--- a/packages/docs/content/docs/props.mdx
+++ b/packages/docs/content/docs/props.mdx
@@ -7,14 +7,15 @@ import { MentisDemo } from "@/components";
 
 ## Props
 
-| Name                | Type                    | Required | Description                                                                                    |
-| ------------------- | ----------------------- | -------- | ---------------------------------------------------------------------------------------------- |
-| defaultValue        | string                  | No       | The initial value of the input.                                                                |
-| options             | MentionOption[]         | Yes      | Array of mentionable options. See [Options](./options) for more.                               |
-| onChange            | (value: string) => void | No       | Callback fired when the input value changes.                                                   |
-| keepTriggerOnSelect | boolean                 | No       | Whether to keep the trigger character (e.g. '@') when an option is selected. Defaults to true. |
-| trigger             | string                  | No       | The character or string that triggers the mention dropdown. Defaults to '@'.                   |
-| slotsProps          | SlotProps               | No       | Customization for internal component slots (see below).                                        |
+| Name                | Type                    | Required | Description                                                                                            |
+| ------------------- | ----------------------- | -------- | ------------------------------------------------------------------------------------------------------ |
+| defaultValue        | string                  | No       | The initial value of the input.                                                                        |
+| options             | MentionOption[]         | Yes      | Array of mentionable options. See [Options](./options) for more.                                       |
+| slotsProps          | SlotProps               | No       | Customization for internal component slots (see below).                                                |
+| keepTriggerOnSelect | boolean                 | No       | Whether to keep the trigger character (e.g. '@') when an option is selected. Defaults to true.         |
+| trigger             | string                  | No       | The character or string that triggers the mention dropdown. Defaults to '@'.                           |
+| autoConvertMentions | boolean                 | No       | Whether to automatically convert text mentions to chips when typing space or enter. Defaults to false. |
+| onChange            | (value: string) => void | No       | Callback fired when the input value changes.                                                           |
 
 ### MentionOption
 
@@ -68,7 +69,7 @@ type SlotProps = Partial<{
 
 ---
 
-#### `keepTriggerOnSelect`
+### `keepTriggerOnSelect`
 
 If `true` (default), the trigger character (such as `@`) will be kept in the input when an option is selected. If `false`, the trigger character will be removed before the selected label.
 
@@ -80,7 +81,7 @@ If `true` (default), the trigger character (such as `@`) will be kept in the inp
 
 ---
 
-#### `trigger`
+### `trigger`
 
 The `trigger` prop allows you to customize which character or string opens the mention dropdown. By default, this is set to `@`, but you can use any character (e.g., `#`) or even a multi-character string (e.g., `::`).
 
@@ -91,3 +92,23 @@ The `trigger` prop allows you to customize which character or string opens the m
 <MentisDemo trigger="#" />
 
 This will open the mention dropdown when the user types `#` instead of `@`.
+
+---
+
+### `autoConvertMentions`
+
+When `true`, the component will automatically convert text mentions to chips when the user types a space or presses Enter. This is useful for scenarios where users type mentions manually without selecting from the dropdown.
+
+```tsx
+<MentionInput autoConvertMentions={true} ... />
+```
+
+**How it works:**
+
+- When enabled, the component monitors for space characters and Enter key presses
+- It scans the text for patterns like `@username` that match your options
+- Matching text is automatically converted to chips
+- The conversion happens asynchronously to ensure DOM updates are complete
+- This feature works independently of the paste functionality, which has its own mention parsing
+
+**⚠️ Performance Warning:** This feature is not enabled by default as it requires additional performance testing in production environments. The automatic conversion process runs on every space/enter key press and may impact performance with large option lists or frequent typing.

--- a/packages/docs/content/docs/styling.mdx
+++ b/packages/docs/content/docs/styling.mdx
@@ -12,7 +12,7 @@ You can customize the appearance of each part of the `MentionInput` component by
 
 - `container`: The outer container
 - `contentEditable`: The contentEditable element for rich text input
-- `listbox`: The dropdown list container
+- `modal`: The dropdown list container
 - `option`: Each option in the list
 - `highlightedClassName`: Applied to the currently highlighted option
 - `noOptions`: The element shown when there are no options
@@ -29,7 +29,7 @@ Here's an example using your own CSS classes (see `index.css` for definitions):
   slotsProps={{
     container: { className: "mentis-demo-container" },
     contentEditable: { className: "mentis-demo-input" },
-    listbox: { className: "mentis-demo-listbox" },
+    modal: { className: "mentis-demo-listbox" },
     option: { className: "mentis-demo-option" },
     highlightedClassName: "mentis-demo-option-highlighted",
     noOptions: { className: "mentis-demo-no-options" },
@@ -54,7 +54,7 @@ Here's an example using Tailwind CSS utility classes directly in the `slotsProps
       className:
         "w-full rounded-xl border border-gray-300 bg-white px-4 py-3 text-base shadow-sm focus:border-blue-500 focus:ring-2 focus:ring-blue-200 outline-none transition placeholder-gray-400",
     },
-    listbox: {
+    modal: {
       className:
         "absolute z-10 mt-2 w-full bg-white border border-gray-200 rounded-xl shadow-lg max-h-60 overflow-auto",
     },

--- a/packages/docs/src/components/MentisDemo.tsx
+++ b/packages/docs/src/components/MentisDemo.tsx
@@ -3,7 +3,7 @@ import { DemoFallback } from "./DemoFallback";
 import { Suspense } from "react";
 import type { MentionInputProps } from "mentis";
 
-export function MentisDemo(props: MentionInputProps) {
+export function MentisDemo(props: Partial<MentionInputProps>) {
   return (
     <Suspense fallback={<DemoFallback />}>
       <MentisDemoClient {...props} />

--- a/packages/mentis/package.json
+++ b/packages/mentis/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mentis",
-  "version": "0.1.0-alpha.1",
+  "version": "0.1.0-alpha.2",
   "description": "A flexible mention tagger for React that hooks into your existing inputs.",
   "type": "module",
   "license": "MIT",

--- a/packages/mentis/playground/src/App.tsx
+++ b/packages/mentis/playground/src/App.tsx
@@ -13,7 +13,8 @@ export function App() {
     <>
       <div style={{ width: "300px", height: "200px", overflowY: "auto" }}>
         <MentionInput
-          keepTriggerOnSelect
+          keepTriggerOnSelect={false}
+          autoConvertMentions={true}
           defaultValue={value}
           options={options}
           onChange={setValue}

--- a/packages/mentis/src/MentionInput.css
+++ b/packages/mentis/src/MentionInput.css
@@ -30,8 +30,8 @@
   border-radius: 4px;
 }
 
-.mention-listbox {
-  position: fixed;
+.mention-modal {
+  position: absolute;
   background: #fff;
   border: 1px solid #ccc;
   text-align: left;

--- a/packages/mentis/src/MentionInput.tsx
+++ b/packages/mentis/src/MentionInput.tsx
@@ -2,13 +2,13 @@ import React from "react";
 import "./MentionInput.css";
 import type { MentionInputProps } from "./types/MentionInput.types";
 import { useContentEditableMention } from "./hooks/useContentEditableMention";
-import { MentionListbox } from "./components/MentionListbox";
+import { MentionModal } from "./components/MentionModal";
 
 export const MentionInput: React.FC<MentionInputProps> = ({
-  defaultValue,
+  defaultValue = "",
   options,
   slotsProps,
-  keepTriggerOnSelect,
+  keepTriggerOnSelect = true,
   trigger = "@",
   onChange,
 }) => {
@@ -46,7 +46,7 @@ export const MentionInput: React.FC<MentionInputProps> = ({
             : undefined
         }
         aria-haspopup="listbox"
-        aria-controls={showModal ? "mention-listbox" : undefined}
+        aria-controls={showModal ? "mention-modal" : undefined}
         {...slotsProps?.contentEditable}
         ref={editorRef}
         contentEditable
@@ -58,7 +58,7 @@ export const MentionInput: React.FC<MentionInputProps> = ({
         onPaste={handlePaste}
       />
       {showModal && (
-        <MentionListbox
+        <MentionModal
           modalPosition={modalPosition}
           filteredOptions={filteredOptions}
           highlightedIndex={highlightedIndex}

--- a/packages/mentis/src/MentionInput.tsx
+++ b/packages/mentis/src/MentionInput.tsx
@@ -10,6 +10,7 @@ export const MentionInput: React.FC<MentionInputProps> = ({
   slotsProps,
   keepTriggerOnSelect = true,
   trigger = "@",
+  autoConvertMentions = false,
   onChange,
 }) => {
   const {
@@ -29,6 +30,7 @@ export const MentionInput: React.FC<MentionInputProps> = ({
     defaultValue,
     keepTriggerOnSelect,
     trigger,
+    autoConvertMentions,
     onChange,
   });
 
@@ -51,7 +53,7 @@ export const MentionInput: React.FC<MentionInputProps> = ({
         ref={editorRef}
         contentEditable
         suppressContentEditableWarning
-        onInput={handleInput}
+        onInput={(e) => handleInput(e.nativeEvent)}
         onKeyDown={handleKeyDown}
         onFocus={handleFocus}
         onBlur={handleBlur}

--- a/packages/mentis/src/components/MentionModal.tsx
+++ b/packages/mentis/src/components/MentionModal.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import type { MentionInputProps } from "../types/MentionInput.types";
 import { getOptionClassName } from "../utils/getOptionClassName";
 
-type MentionListboxProps = {
+type MentionModalProps = {
   modalPosition: { top: number; left: number };
   filteredOptions: MentionInputProps["options"];
   highlightedIndex: number;
@@ -10,7 +10,7 @@ type MentionListboxProps = {
   handleSelect: (option: MentionInputProps["options"][number]) => void;
 };
 
-export const MentionListbox: React.FC<MentionListboxProps> = ({
+export const MentionModal: React.FC<MentionModalProps> = ({
   modalPosition,
   filteredOptions,
   highlightedIndex,
@@ -18,9 +18,9 @@ export const MentionListbox: React.FC<MentionListboxProps> = ({
   handleSelect,
 }) => (
   <div
-    className="mention-listbox"
-    {...slotsProps?.listbox}
-    id="mention-listbox"
+    className="mention-modal"
+    {...slotsProps?.modal}
+    id="mention-modal"
     role="listbox"
     style={{
       top: modalPosition.top,

--- a/packages/mentis/src/hooks/useContentEditableMention.ts
+++ b/packages/mentis/src/hooks/useContentEditableMention.ts
@@ -16,16 +16,16 @@ import { parseMentionsInText } from "../utils/parseMentionsInText";
 
 type UseContentEditableMentionProps = {
   options: MentionOption[];
-  defaultValue?: string;
-  keepTriggerOnSelect?: boolean;
-  trigger?: string;
+  defaultValue: string;
+  keepTriggerOnSelect: boolean;
+  trigger: string;
   onChange?: (value: string) => void;
 };
 
 export function useContentEditableMention({
   options,
   defaultValue = "",
-  keepTriggerOnSelect = false,
+  keepTriggerOnSelect,
   trigger = "@",
   onChange,
 }: UseContentEditableMentionProps) {
@@ -93,10 +93,9 @@ export function useContentEditableMention({
     setHighlightedIndex(0);
     setMentionStart(mentionDetection.start);
 
-    const rect = editorRef.current.getBoundingClientRect();
     setModalPosition({
-      top: rect.bottom,
-      left: rect.left,
+      top: editorRef.current.offsetTop + editorRef.current.offsetHeight,
+      left: editorRef.current.offsetLeft,
     });
   };
 

--- a/packages/mentis/src/hooks/useContentEditableMention.ts
+++ b/packages/mentis/src/hooks/useContentEditableMention.ts
@@ -24,9 +24,9 @@ type UseContentEditableMentionProps = {
 
 export function useContentEditableMention({
   options,
-  defaultValue = "",
+  defaultValue,
   keepTriggerOnSelect,
-  trigger = "@",
+  trigger,
   onChange,
 }: UseContentEditableMentionProps) {
   const [showModal, setShowModal] = useState<boolean>(false);

--- a/packages/mentis/src/index.ts
+++ b/packages/mentis/src/index.ts
@@ -8,5 +8,5 @@ export type {
   SlotProps,
   ContentEditableInputCustomProps,
   OptionProps,
-  ListboxProps,
+  ModalProps,
 } from "./types/SlotProps.types";

--- a/packages/mentis/src/types/MentionInput.types.ts
+++ b/packages/mentis/src/types/MentionInput.types.ts
@@ -11,5 +11,6 @@ export type MentionInputProps = {
   slotsProps?: SlotProps;
   keepTriggerOnSelect?: boolean;
   trigger?: string;
+  autoConvertMentions?: boolean;
   onChange?: (value: string) => void;
 };

--- a/packages/mentis/src/types/SlotProps.types.ts
+++ b/packages/mentis/src/types/SlotProps.types.ts
@@ -10,7 +10,7 @@ export type ContentEditableInputCustomProps = Omit<
   | "onPaste"
 >;
 
-export type ListboxProps = Omit<
+export type ModalProps = Omit<
   React.HTMLAttributes<HTMLDivElement>,
   "id" | "role" | "style"
 >;
@@ -23,7 +23,7 @@ export type OptionProps = Omit<
 export type SlotProps = Partial<{
   container: React.HTMLAttributes<HTMLDivElement>;
   contentEditable: ContentEditableInputCustomProps;
-  listbox: ListboxProps;
+  modal: ModalProps;
   option: OptionProps;
   noOptions: React.HTMLAttributes<HTMLDivElement>;
   highlightedClassName: string;

--- a/packages/mentis/src/utils/convertTextToChips.ts
+++ b/packages/mentis/src/utils/convertTextToChips.ts
@@ -1,0 +1,200 @@
+import type { MentionOption } from "../types/MentionInput.types";
+import { getCaretPosition } from "./getCaretPosition";
+
+type ConvertTextToChipsProps = {
+  editorRef: React.RefObject<HTMLDivElement | null>;
+  options: MentionOption[];
+  keepTriggerOnSelect: boolean;
+  trigger: string;
+};
+
+export const convertTextToChips = ({
+  editorRef,
+  options,
+  keepTriggerOnSelect,
+  trigger,
+}: ConvertTextToChipsProps): void => {
+  if (!editorRef.current) return;
+
+  const selection = window.getSelection();
+  const currentCaretPos = getCaretPosition(editorRef.current);
+
+  // Check if there are any mentions that should be converted to chips
+  const tempDiv = document.createElement("div");
+  tempDiv.innerHTML = editorRef.current.innerHTML;
+
+  // Only process text nodes that aren't already inside chips
+  const walker = document.createTreeWalker(tempDiv, NodeFilter.SHOW_TEXT, {
+    acceptNode: (node) => {
+      // Check if this text node is inside a mention chip
+      let parent = node.parentNode;
+      while (parent && parent !== tempDiv) {
+        if (parent.nodeType === Node.ELEMENT_NODE) {
+          const element = parent as Element;
+          if (element.classList.contains("mention-chip")) {
+            return NodeFilter.FILTER_REJECT;
+          }
+        }
+        parent = parent.parentNode;
+      }
+      return NodeFilter.FILTER_ACCEPT;
+    },
+  });
+
+  let hasChanges = false;
+  const textNodes: Text[] = [];
+  let node;
+  while ((node = walker.nextNode())) {
+    textNodes.push(node as Text);
+  }
+
+  for (const textNode of textNodes) {
+    const nodeText = textNode.textContent || "";
+
+    // Check for mentions that need to be converted
+    const mentionWithTriggerRegex = new RegExp(
+      `\\${trigger}([a-zA-Z0-9_]+)(?=\\s|$)`,
+      "g"
+    );
+    let match;
+    const replacements: Array<{ start: number; end: number; option: any }> = [];
+
+    while ((match = mentionWithTriggerRegex.exec(nodeText)) !== null) {
+      const mentionText = match[1];
+      const matchingOption = options.find(
+        (option) =>
+          option.label.toLowerCase() === mentionText.toLowerCase() ||
+          option.value.toLowerCase() === mentionText.toLowerCase()
+      );
+
+      if (matchingOption) {
+        replacements.push({
+          start: match.index,
+          end: match.index + match[0].length,
+          option: matchingOption,
+        });
+      }
+    }
+
+    // When keepTriggerOnSelect is false, also check for standalone mentions
+    if (!keepTriggerOnSelect && options.length > 0) {
+      const mentionWithoutTriggerRegex = new RegExp(
+        `\\b(${options
+          .map((opt) =>
+            [opt.label, opt.value]
+              .map((val) => val.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"))
+              .join("|")
+          )
+          .join("|")})(?=\\s|$)`,
+        "gi"
+      );
+
+      while ((match = mentionWithoutTriggerRegex.exec(nodeText)) !== null) {
+        const mentionText = match[0];
+        const matchingOption = options.find(
+          (option) =>
+            option.label.toLowerCase() === mentionText.toLowerCase() ||
+            option.value.toLowerCase() === mentionText.toLowerCase()
+        );
+
+        if (matchingOption) {
+          // Check if this overlaps with any trigger-based replacement
+          const overlaps = replacements.some(
+            (r) =>
+              match!.index < r.end && match!.index + match![0].length > r.start
+          );
+
+          if (!overlaps) {
+            replacements.push({
+              start: match.index,
+              end: match.index + match[0].length,
+              option: matchingOption,
+            });
+          }
+        }
+      }
+    }
+
+    if (replacements.length > 0) {
+      hasChanges = true;
+      // Sort replacements by position (reverse order for easier processing)
+      replacements.sort((a, b) => b.start - a.start);
+
+      // Apply replacements
+      for (const replacement of replacements) {
+        const beforeText = nodeText.substring(0, replacement.start);
+        const afterText = nodeText.substring(replacement.end);
+
+        // Create mention chip
+        const mentionElement = document.createElement("span");
+        mentionElement.className = "mention-chip";
+        mentionElement.contentEditable = "false";
+        mentionElement.dataset.value = replacement.option.value;
+        mentionElement.dataset.label = replacement.option.label;
+        mentionElement.textContent = keepTriggerOnSelect
+          ? `${trigger}${replacement.option.label}`
+          : replacement.option.label;
+
+        // Create fragment with replacement
+        const fragment = document.createDocumentFragment();
+        if (beforeText) {
+          fragment.appendChild(document.createTextNode(beforeText));
+        }
+        fragment.appendChild(mentionElement);
+        if (afterText) {
+          fragment.appendChild(document.createTextNode(afterText));
+        }
+
+        // Replace the text node
+        textNode.parentNode?.replaceChild(fragment, textNode);
+        break; // Process one replacement at a time to avoid issues
+      }
+    }
+  }
+
+  if (hasChanges) {
+    // Update the editor content
+    editorRef.current.innerHTML = tempDiv.innerHTML;
+
+    // Restore caret position (approximately)
+    if (selection && selection.rangeCount > 0) {
+      try {
+        const range = document.createRange();
+        const walker = document.createTreeWalker(
+          editorRef.current,
+          NodeFilter.SHOW_TEXT,
+          null
+        );
+
+        let charCount = 0;
+        let targetNode = null;
+        let targetOffset = 0;
+
+        while (walker.nextNode()) {
+          const node = walker.currentNode as Text;
+          const nodeLength = node.textContent?.length || 0;
+
+          if (charCount + nodeLength >= currentCaretPos) {
+            targetNode = node;
+            targetOffset = currentCaretPos - charCount;
+            break;
+          }
+          charCount += nodeLength;
+        }
+
+        if (targetNode) {
+          range.setStart(
+            targetNode,
+            Math.min(targetOffset, targetNode.textContent?.length || 0)
+          );
+          range.collapse(true);
+          selection.removeAllRanges();
+          selection.addRange(range);
+        }
+      } catch (e) {
+        // If caret positioning fails, focus at the end
+        editorRef.current.focus();
+      }
+    }
+  }
+};


### PR DESCRIPTION
## PR Description:

### Related Issues

Fixes #18, #19, #20

### Summary of Changes

This pull request introduces significant enhancements to the `MentionInput` component, including an opt-in auto-conversion feature for mentions and several key bug fixes.

**Key Changes:**

* **Auto-Convert Mentions (`autoConvertMentions` prop):**
    * Adds a new `autoConvertMentions` boolean prop to `MentionInputProps`, defaulting to `false`.
    * When enabled, this feature automatically converts manually typed mention text into chips when the user types a space or presses Enter.
    * The conversion logic works for both:
        * `keepTriggerOnSelect: true` (e.g., converts "@alice" to chips)
        * `keepTriggerOnSelect: false` (e.g., converts "Alice" to chips if "Alice" is in the options)
    * This provides better default performance by allowing users to explicitly enable the auto-conversion feature if desired.
* **Modal (formerly Listbox) Improvements:**
    * `Listbox` has been renamed to `Modal` for clarity.
    * Fixed absolute positioning issues with the `Modal` (Listbox).
    * Corrected content positioning within the `Modal` (Listbox).
* **Chips Display Fix:**
    * Ensures chips are correctly displayed when `keepTriggerOnSelect` is set to `false`.
* **`keepTriggerOnSelect` Default:**
    * Set `keepTriggerOnSelect` default to `true`.
* **Bug Fix for Existing Chips:**
    * Implemented a filter function within the `TreeWalker` to prevent the auto-conversion logic from affecting chips that have already been created. This ensures only new, manually typed mention text is processed for conversion.