### PR TITLE
test: cover placeholder clearing and Tab fall-through

### DIFF
--- a/packages/mentis/tests/input.test.tsx
+++ b/packages/mentis/tests/input.test.tsx
@@ -10,6 +10,32 @@ const options: MentionOption[] = [
   { label: "Jane Smith", value: "jane" },
 ];
 
+// Mirrors the usual consumer setup: dataValue is owned by the parent and fed
+// back through onChange, with an external control that resets it to "".
+const ControlledMentionInput = ({
+  initialDataValue,
+}: {
+  initialDataValue: string;
+}) => {
+  const [dataValue, setDataValue] = React.useState(initialDataValue);
+
+  return (
+    <>
+      <MentionInput
+        options={options}
+        dataValue={dataValue}
+        onChange={(value) => setDataValue(value.dataValue)}
+        slotsProps={{
+          contentEditable: {
+            "data-placeholder": "Say something...",
+          },
+        }}
+      />
+      <button onClick={() => setDataValue("")}>Clear</button>
+    </>
+  );
+};
+
 describe("Input props", () => {
   test("Value should be displayed", () => {
     const value = "Hello @john, how are you?";
@@ -190,6 +216,71 @@ describe("Input props", () => {
     );
 
     // Element should be empty and placeholder should be visible via CSS
+    expect(editorElement).toHaveTextContent("");
+    expect(editorElement.innerHTML).toBe("");
+  });
+
+  test("Placeholder should reappear when a dataValue mention is cleared", async () => {
+    const customPlaceholder = "Say something...";
+    const { rerender } = render(
+      <MentionInput
+        options={options}
+        dataValue="john"
+        slotsProps={{
+          contentEditable: {
+            "data-placeholder": customPlaceholder,
+          },
+        }}
+      />
+    );
+
+    const editorElement = screen.getByRole("combobox");
+    expect(editorElement).toHaveTextContent("@John Doe");
+
+    // Clear the content by setting dataValue back to an empty string
+    rerender(
+      <MentionInput
+        options={options}
+        dataValue=""
+        slotsProps={{
+          contentEditable: {
+            "data-placeholder": customPlaceholder,
+          },
+        }}
+      />
+    );
+
+    // Element must be truly empty for the :empty::before placeholder to render
+    expect(editorElement).toHaveTextContent("");
+    expect(editorElement.innerHTML).toBe("");
+  });
+
+  test("Placeholder should reappear when a controlled mention dataValue is cleared", async () => {
+    render(<ControlledMentionInput initialDataValue="john" />);
+
+    const user = userEvent.setup();
+    const editorElement = screen.getByRole("combobox");
+    expect(editorElement).toHaveTextContent("@John Doe");
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    // Element must be truly empty for the :empty::before placeholder to render
+    expect(editorElement).toHaveTextContent("");
+    expect(editorElement.innerHTML).toBe("");
+  });
+
+  test("Placeholder should reappear when controlled typed content is cleared", async () => {
+    render(<ControlledMentionInput initialDataValue="" />);
+
+    const user = userEvent.setup();
+    const editorElement = screen.getByRole("combobox");
+
+    await user.type(editorElement, "Hello world");
+    expect(editorElement).toHaveTextContent("Hello world");
+
+    await user.click(screen.getByRole("button", { name: "Clear" }));
+
+    // Element must be truly empty for the :empty::before placeholder to render
     expect(editorElement).toHaveTextContent("");
     expect(editorElement.innerHTML).toBe("");
   });

--- a/packages/mentis/tests/keyboard.test.tsx
+++ b/packages/mentis/tests/keyboard.test.tsx
@@ -245,6 +245,48 @@ describe("Keyboard functionality", () => {
     });
   });
 
+  test("Should call onKeyDown for Tab when modal is closed", async () => {
+    const mockOnKeyDown = vi.fn();
+    render(<MentionInput options={options} onKeyDown={mockOnKeyDown} />);
+
+    const user = userEvent.setup();
+    const editorElement = screen.getByRole("combobox");
+
+    await user.click(editorElement);
+    expect(screen.queryByRole("listbox")).not.toBeInTheDocument();
+
+    await user.keyboard("{Tab}");
+
+    // Tab must fall through to the consumer when there is nothing to select
+    expect(mockOnKeyDown).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "Tab",
+        defaultPrevented: false,
+      })
+    );
+  });
+
+  test("Should call onKeyDown for Tab when modal is open with no matching options", async () => {
+    const mockOnKeyDown = vi.fn();
+    render(<MentionInput options={options} onKeyDown={mockOnKeyDown} />);
+
+    const user = userEvent.setup();
+    const editorElement = screen.getByRole("combobox");
+
+    // Open the modal with a query that matches none of the options
+    await user.type(editorElement, "@zzz");
+    mockOnKeyDown.mockClear();
+
+    await user.keyboard("{Tab}");
+
+    expect(mockOnKeyDown).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "Tab",
+        defaultPrevented: false,
+      })
+    );
+  });
+
   test("Should close modal with Escape", async () => {
     const options = [
       { label: "John Doe", value: "john" },


### PR DESCRIPTION
Follow-up to #71. Tests only — no source changes.

## What this adds

**`tests/input.test.tsx`** — placeholder coverage for the `dataValue` path, which previously only existed for `displayValue`:

- `Placeholder should reappear when a dataValue mention is cleared` — rerender from `dataValue="john"` to `""`
- `Placeholder should reappear when a controlled mention dataValue is cleared` — full controlled wrapper with a Clear button
- `Placeholder should reappear when controlled typed content is cleared` — type text, then Clear

Each asserts `innerHTML === ""`, since `.content-editable-input:empty::before` only renders on a truly empty element.

**`tests/keyboard.test.tsx`** — Tab now only selects when the modal is open with matching options, so these pin the fall-through:

- `Should call onKeyDown for Tab when modal is closed`
- `Should call onKeyDown for Tab when modal is open with no matching options`

## Notes

- All 5 new tests pass. Typecheck is clean.
- These are regression guards, not a repro. The reported placeholder bug does not reproduce under happy-dom — whatever breaks in a real browser involves DOM behaviour happy-dom does not model.
- CI is red on `main` independently of this branch: 3 pre-existing failures in `extractMentionData.test.ts`, 1 in `newlines.test.tsx`, plus `newlines.test.tsx:26` which #71 broke via `document.execCommand` not existing in happy-dom. A fix for that last one is coming in a separate branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)