### PR TITLE
fix: insert Enter newlines without execCommand in test DOMs

### DIFF
--- a/packages/mentis/src/hooks/useContentEditableMention.ts
+++ b/packages/mentis/src/hooks/useContentEditableMention.ts
@@ -6,6 +6,7 @@ import type {
 import { insertMentionIntoDOM } from "../utils/insertMentionIntoDOM";
 import { extractMentionData } from "../utils/extractMentionData";
 import { removeTriggerAndQuery } from "../utils/removeTriggerAndQuery";
+import { insertNewlineAtCaret } from "../utils/insertNewlineAtCaret";
 import { useMentionState } from "./useMentionState";
 import { useMentionInput } from "./useMentionInput";
 import { useMentionPaste } from "./useMentionPaste";
@@ -137,7 +138,9 @@ export function useContentEditableMention({
           return;
         }
       }
-      document.execCommand("insertText", false, "\n");
+      if (editorRef.current) {
+        insertNewlineAtCaret(editorRef.current);
+      }
       return;
     }
 

--- a/packages/mentis/src/utils/insertNewlineAtCaret.ts
+++ b/packages/mentis/src/utils/insertNewlineAtCaret.ts
@@ -1,0 +1,39 @@
+/**
+ * Inserts a line break at the current caret position inside `element`.
+ *
+ * `document.execCommand` is deprecated but still gives the best result in a
+ * real browser: it keeps the caret on the new line and leaves the undo stack
+ * intact. It is missing in DOM implementations used for testing, so fall back
+ * to a Range-based `<br>` insertion there.
+ */
+export const insertNewlineAtCaret = (element: HTMLElement): void => {
+  const selection = window.getSelection();
+  if (!selection || selection.rangeCount === 0) return;
+
+  const range = selection.getRangeAt(0);
+  if (!element.contains(range.commonAncestorContainer)) return;
+
+  if (typeof document.execCommand === "function") {
+    document.execCommand("insertText", false, "\n");
+    return;
+  }
+
+  range.deleteContents();
+
+  const lineBreak = document.createElement("br");
+  range.insertNode(lineBreak);
+
+  // Move the caret after the break so subsequent typing lands on the new line
+  range.setStartAfter(lineBreak);
+  range.collapse(true);
+  selection.removeAllRanges();
+  selection.addRange(range);
+
+  // execCommand emits an input event of its own, so emit one here too and keep
+  // both paths looking the same to the input handler
+  element.dispatchEvent(
+    typeof InputEvent === "function"
+      ? new InputEvent("input", { bubbles: true, inputType: "insertLineBreak" })
+      : new Event("input", { bubbles: true })
+  );
+};

--- a/packages/mentis/tests/newlines.test.tsx
+++ b/packages/mentis/tests/newlines.test.tsx
@@ -32,6 +32,38 @@ describe("Newline handling", () => {
     );
   });
 
+  test("Should insert a single line break per Enter press", async () => {
+    render(<MentionInput options={options} />);
+
+    const user = userEvent.setup();
+    const editorElement = screen.getByRole("combobox");
+
+    await user.type(editorElement, "First line{enter}Second line");
+
+    // One break, not the doubled-up block element contentEditable defaults to
+    expect(editorElement.querySelectorAll("br")).toHaveLength(1);
+    expect(editorElement.querySelectorAll("div")).toHaveLength(0);
+  });
+
+  test("Should insert a newline when Enter is pressed with no matching options", async () => {
+    const mockOnChange = vi.fn();
+    render(<MentionInput options={options} onChange={mockOnChange} />);
+
+    const user = userEvent.setup();
+    const editorElement = screen.getByRole("combobox");
+
+    // Open the modal with a query that matches none of the options
+    await user.type(editorElement, "@zzz");
+    await user.type(editorElement, "{enter}after");
+
+    expect(mockOnChange).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        dataValue: "@zzz\nafter",
+        mentions: [],
+      })
+    );
+  });
+
   test("Should extract newlines correctly from contentEditable with <br> elements", () => {
     // Create a test element with <br> tags
     const testElement = document.createElement("div");

--- a/packages/mentis/tests/utils/insertNewlineAtCaret.test.ts
+++ b/packages/mentis/tests/utils/insertNewlineAtCaret.test.ts
@@ -1,0 +1,103 @@
+import { describe, test, expect, vi, afterEach } from "vitest";
+import { insertNewlineAtCaret } from "../../src/utils/insertNewlineAtCaret";
+
+const renderEditor = (textContent: string) => {
+  const element = document.createElement("div");
+  element.contentEditable = "true";
+  element.textContent = textContent;
+  document.body.appendChild(element);
+  return element;
+};
+
+const placeCaretAtEnd = (element: HTMLElement) => {
+  const range = document.createRange();
+  const selection = window.getSelection();
+  range.selectNodeContents(element);
+  range.collapse(false);
+  selection?.removeAllRanges();
+  selection?.addRange(range);
+};
+
+afterEach(() => {
+  document.body.innerHTML = "";
+  window.getSelection()?.removeAllRanges();
+  vi.unstubAllGlobals();
+  // @ts-expect-error execCommand is absent in the test DOM, so drop any stub
+  delete document.execCommand;
+});
+
+describe("insertNewlineAtCaret", () => {
+  test("should delegate to execCommand when it is available", () => {
+    const execCommand = vi.fn();
+    // @ts-expect-error execCommand is absent in the test DOM
+    document.execCommand = execCommand;
+
+    const element = renderEditor("First line");
+    placeCaretAtEnd(element);
+
+    insertNewlineAtCaret(element);
+
+    expect(execCommand).toHaveBeenCalledWith("insertText", false, "\n");
+    // execCommand owns the DOM mutation, so nothing is inserted by hand
+    expect(element.innerHTML).toBe("First line");
+  });
+
+  test("should insert a <br> at the caret when execCommand is unavailable", () => {
+    const element = renderEditor("First line");
+    placeCaretAtEnd(element);
+
+    insertNewlineAtCaret(element);
+
+    expect(element.innerHTML).toBe("First line<br>");
+  });
+
+  test("should leave the caret after the inserted <br>", () => {
+    const element = renderEditor("First line");
+    placeCaretAtEnd(element);
+
+    insertNewlineAtCaret(element);
+
+    const selection = window.getSelection();
+    const range = selection?.getRangeAt(0);
+    const lineBreak = element.querySelector("br");
+
+    expect(range?.collapsed).toBe(true);
+    expect(range?.startContainer).toBe(element);
+    expect(range?.startOffset).toBe(
+      Array.from(element.childNodes).indexOf(lineBreak as ChildNode) + 1
+    );
+  });
+
+  test("should emit an input event so the change is picked up", () => {
+    const element = renderEditor("First line");
+    placeCaretAtEnd(element);
+
+    const onInput = vi.fn();
+    element.addEventListener("input", onInput);
+
+    insertNewlineAtCaret(element);
+
+    expect(onInput).toHaveBeenCalledTimes(1);
+    expect(onInput.mock.calls[0][0].bubbles).toBe(true);
+  });
+
+  test("should do nothing when there is no selection", () => {
+    const element = renderEditor("First line");
+    window.getSelection()?.removeAllRanges();
+
+    insertNewlineAtCaret(element);
+
+    expect(element.innerHTML).toBe("First line");
+  });
+
+  test("should do nothing when the caret is outside the element", () => {
+    const element = renderEditor("First line");
+    const outside = renderEditor("Somewhere else");
+    placeCaretAtEnd(outside);
+
+    insertNewlineAtCaret(element);
+
+    expect(element.innerHTML).toBe("First line");
+    expect(outside.innerHTML).toBe("Somewhere else");
+  });
+});


### PR DESCRIPTION
Follow-up to #71.

## Problem

The Enter handler added in #71 called `document.execCommand("insertText", false, "\n")` directly. That API does not exist outside a real browser, so `tests/newlines.test.tsx:26` ("Should preserve newlines in dataValue and displayValue when pressing Enter") started throwing:

```
TypeError: document.execCommand is not a function
    at handleKeyDown (src/hooks/useContentEditableMention.ts:140:16)
```

Enter worked in the browser but was untestable, and it took the suite from 4 failures to 5.

## Change

New `insertNewlineAtCaret` util:

- Keeps `execCommand` where it exists. It is deprecated, but in a real browser it still gives the best result — the caret stays on the new line and the undo stack is preserved. Browser behaviour is unchanged from #71.
- Falls back to inserting a `<br>` at the caret via a `Range`, then moves the caret past it.
- The fallback dispatches a bubbling `input` event, since `execCommand` emits one natively. Without it the fallback path would mutate the DOM without `onChange` firing.
- Bails out when there is no selection, or when the caret sits outside the editor.

`useContentEditableMention` calls the util instead of `execCommand`.

## Tests

`tests/utils/insertNewlineAtCaret.test.ts` (new, 6 tests) covers both branches — `execCommand` delegation via a stub, `<br>` insertion, caret placement, the emitted input event, and the two bail-out cases.

`tests/newlines.test.tsx` adds two:
- `Should insert a single line break per Enter press` — asserts one `<br>` and zero `<div>`, pinning the no-duplication fix from #71
- `Should insert a newline when Enter is pressed with no matching options` — Enter falls through to a newline when the modal is open but nothing matches

## Result

Suite goes from 5 failures to 4. Typecheck and build are clean.

The remaining 4 are pre-existing on `main` and unrelated to this change — 3 in `extractMentionData.test.ts` plus `newlines.test.tsx` "empty `<div>` elements". CI has been red since v0.2.5 because of them, so this branch does not turn CI green on its own.

## Caveat

The `execCommand` path is verified only by asserting it gets called with the right arguments. Its actual DOM effect cannot be exercised under happy-dom, so the assertions about inserted markup all run against the fallback. Worth a manual check in the playground before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)