### PR TITLE
chore: skip docs deploys for commits by other authors

### DIFF
--- a/packages/docs/vercel.json
+++ b/packages/docs/vercel.json
@@ -1,3 +1,4 @@
 {
-  "outputDirectory": ".next"
+  "outputDirectory": ".next",
+  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" = \"Alexanderdunlop\" ]; then exit 1; else exit 0; fi"
 }


### PR DESCRIPTION
Pull requests from outside contributors fail their Vercel check with `Authorization required to deploy` — see #71, which was otherwise fine. This gates the docs build on the commit author.

## Change

`packages/docs/vercel.json`:

```json
{
  "outputDirectory": ".next",
  "ignoreCommand": "if [ \"$VERCEL_GIT_COMMIT_AUTHOR_LOGIN\" = \"Alexanderdunlop\" ]; then exit 1; else exit 0; fi"
}
```

`VERCEL_GIT_COMMIT_AUTHOR_LOGIN` is the GitHub username of the commit author. The [exit codes are inverted](https://vercel.com/kb/guide/how-do-i-use-the-ignored-build-step-field-on-vercel) from what you would expect — **exit 1 continues the build, exit 0 skips it** and marks the deployment `CANCELED`.

Verified locally against the three cases:

| `VERCEL_GIT_COMMIT_AUTHOR_LOGIN` | exit | result |
|---|---|---|
| `Alexanderdunlop` | 1 | builds |
| `webbrain-one` | 0 | skipped |
| unset | 0 | skipped |

Your own previews are unaffected.

## This may not be enough on its own

The failure on #71 is not a build failure — it is the Hobby-plan gate, where only the team owner's commits can deploy. That check runs when the deployment is created, **before** the build starts, while the Ignored Build Step runs during the build after the repo is cloned. So a fork PR may never get far enough to reach this command, and the red check would remain.

I could not confirm the exact ordering from Vercel's docs, so treat that as reasoning about where each step sits rather than something verified. Worth watching the next outside PR to see whether the check goes green, skipped, or still red.

If it stays red, the fallback that definitely stops it is to disable previews by branch:

```json
{ "git": { "deploymentEnabled": { "main": true, "*": false } } }
```

Branch rules are OR'd and a `true` wins, so production still deploys while every other branch is skipped — at the cost of losing preview deploys on your own branches too.

The underlying cause is the Hobby plan. Pro would let you add contributors to the team so their commits deploy normally.

## Note

This file lives in the repo, so a fork PR ships its own copy of it. Setting the same command in Project Settings → Build & Deployment → Ignored Build Step instead would keep it out of contributors' reach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)