### PR TITLE
test: add a Playwright e2e layer for caret, native editing and clipboard

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,143 @@
+name: E2E
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  schedule:
+    # 03:17 UTC nightly — the full browser matrix, including mobile.
+    - cron: "17 3 * * *"
+  workflow_dispatch:
+
+concurrency:
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # On a PR, chromium only: it is the fast signal, and the suite runs in seconds,
+  # so there is nothing to shard.
+  chromium:
+    name: chromium
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.1.0
+
+      - name: Set node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Typecheck e2e
+        run: pnpm typecheck:e2e
+
+      - name: Resolve Playwright version
+        id: playwright
+        run: |
+          echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache browsers
+        id: browser-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}-chromium
+
+      - name: Install browser
+        if: steps.browser-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      # The browser binaries are cached but the system libraries they link
+      # against are not, so they still have to be installed on a cache hit.
+      - name: Install browser system dependencies
+        if: steps.browser-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: Test
+        run: pnpm exec playwright test --project=chromium
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-chromium
+          path: playwright-report/
+          retention-days: 7
+
+  # Nightly: every browser, plus the mobile project. Mobile keyboards and touch
+  # carets are where contentEditable libraries die, so they get checked daily even
+  # though they are too slow to gate every PR on.
+  matrix:
+    name: ${{ matrix.project }}
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - project: chromium
+            browser: chromium
+          - project: firefox
+            browser: firefox
+          - project: webkit
+            browser: webkit
+          # The mobile project emulates a Pixel 7 but drives the chromium binary.
+          - project: mobile-chrome
+            browser: chromium
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4.1.0
+
+      - name: Set node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+
+      - name: Install
+        run: pnpm install --frozen-lockfile
+
+      - name: Resolve Playwright version
+        id: playwright
+        run: |
+          echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+
+      - name: Cache browsers
+        id: browser-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ steps.playwright.outputs.version }}-${{ matrix.browser }}
+
+      - name: Install browser
+        if: steps.browser-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps ${{ matrix.browser }}
+
+      - name: Install browser system dependencies
+        if: steps.browser-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps ${{ matrix.browser }}
+
+      - name: Test
+        run: pnpm exec playwright test --project=${{ matrix.project }}
+
+      - name: Upload report
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ matrix.project }}
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,12 @@ dist/
 .DS_Store
 .eslintcache
 
+# Matches at any depth, so the root CLAUDE.md stays personal and local.
 CLAUDE.md
+# ...but the e2e one is a shared instruction file: it carries the "pin bugs with
+# test.fixme, never edit packages/mentis/src" constraint that anyone's agent
+# needs before touching a spec.
+!e2e/CLAUDE.md
 
 packages/mentis/README.md
 packages/mentis/LICENSE

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,10 @@ CLAUDE.md
 
 packages/mentis/README.md
 packages/mentis/LICENSE
+
+# Playwright — reports, traces and downloaded browser binaries
+test-results/
+playwright-report/
+blob-report/
+playwright/.cache/
+.playwright/

--- a/docs/prompts/e2e-harness.md
+++ b/docs/prompts/e2e-harness.md
@@ -1,0 +1,186 @@
+# Prompt — add Playwright + a real behaviour spec to mentis
+
+> Branch: `test/e2e-harness` · Worktree: `../mentis-e2e`
+>
+> Paste everything below the line into a fresh Claude Code session started in
+> `/Users/alexdunlop/Documents/Github/mentis-e2e`.
+
+---
+
+You are adding an end-to-end test layer to **mentis**, a React mention-tagger library.
+This branch (`test/e2e-harness`, off `main`) does **testing infrastructure only**.
+
+## Why this is needed
+
+mentis is a contenteditable library. Its entire behaviour lives on caret position,
+`Selection`/`Range`, native editing, and clipboard — and the current test environment
+(vitest + happy-dom) only approximates all of those.
+
+There is direct evidence of this in the history: commit `a6fcfd0`,
+_"fix: insert Enter newlines without execCommand in test DOMs"_ — a change made to
+satisfy the fake DOM, not to fix anything for a user. When the test environment
+dictates production code, the environment has stopped being a source of truth.
+
+Separately, the recent `fix:` commits cluster around one root cause (the DOM is the
+state, so every DOM quirk is a correctness bug). Those specific bugs have no
+regression coverage at the level they actually occur:
+
+- `f8516c6` `fix(extractMentionData): walk into nested elements`
+- `afdf240` `fix(useContentEditableMention): show placeholder and fix newline duplication`
+- `5b8fc20` `fix: mention extraction of nested elements, and Enter newlines without execCommand`
+
+## Hard constraints
+
+1. **Do not modify anything in `packages/mentis/src/`.** No behaviour changes, no
+   "while I'm here" fixes. If a test reveals a bug, write it as `test.fixme()` with a
+   one-line note and report it at the end. This branch must be a pure, safe merge.
+2. Existing vitest/happy-dom tests in `packages/mentis/tests/` stay green and stay
+   passing. Do not delete or rewrite them.
+3. Node is pinned to 22.11.0 (`.node-version`). pnpm 10.10.0, turbo, workspace globs
+   are `packages/**`.
+
+## Repo orientation
+
+- Library: `packages/mentis` — `MentionInput` is the public component
+  (`src/components/MentionInput.tsx`), logic in `src/hooks/useContentEditableMention.ts`
+- Playground: `packages/mentis/playground` (vite, `root: './playground'`), run with
+  `pnpm --filter mentis playground`
+- Unit tests: `packages/mentis/tests/*.tsx` — vitest, happy-dom, `globals: true`
+- Docs site: `packages/docs`, with the documented behaviour in
+  `packages/docs/content/docs/*.mdx`
+- CI: `.github/workflows/unit-test.yml` (install → build → typecheck → test)
+
+## The test layering you are establishing
+
+Make this explicit in the README you write, because the current confusion about which
+layer owns what is the underlying problem:
+
+| Layer | Tool | Owns | Must **not** assert |
+|---|---|---|---|
+| Unit | vitest, no DOM | pure functions: trigger detection, offset math, parsing | anything needing a real caret |
+| Component | vitest + happy-dom | props → callbacks → rendered output contract | caret position, native editing, clipboard |
+| **E2E (new)** | Playwright, real browsers | caret after every operation, native editing, undo/redo, clipboard, IME, mobile, a11y tree | — |
+
+## Deliverables, in order
+
+### 1. A dedicated, deterministic harness page — not the demo playground
+
+`packages/mentis/playground/src/App.tsx` is a scratchpad that changes freely; tests
+must not depend on it. Add a separate route/entry (e.g. `playground/e2e.html` +
+`src/E2EHarness.tsx`) that renders `MentionInput` with:
+
+- a fixed, alphabetically stable option list (include two options sharing a label but
+  with different values — that case is currently broken and worth pinning)
+- one instance per meaningful prop configuration: `dataValue` (controlled),
+  `displayValue`, `keepTriggerOnSelect` false, `autoConvertMentions` true, custom
+  `trigger`
+- stable `data-testid` on every instance and on a `<pre data-testid="…-onchange">`
+  that renders the latest `onChange` payload as JSON
+
+Never assert against the demo playground.
+
+### 2. Playwright setup
+
+- `@playwright/test` as a root devDependency; config at repo root or
+  `packages/mentis/playwright.config.ts` — your call, but keep `pnpm test` (vitest)
+  and the e2e command clearly separate. Add a root `test:e2e` script.
+- `webServer` in the config that boots the harness page, with `reuseExistingServer`
+  for local dev
+- projects: `chromium`, `firefox`, `webkit`, plus one mobile project
+  (`Pixel 7` Chrome) — mobile keyboards are where contenteditable libraries die
+- traces/screenshots on first retry; **do not commit** `test-results/`,
+  `playwright-report/`, or browser binaries — update `.gitignore`
+
+### 3. Fixture helpers — invest here, they determine whether this suite gets used
+
+A page-object or fixture module exposing at minimum:
+
+- `typeText(str)` — real key events, not `fill()`
+- `pressKeys("@al{ArrowDown}{Enter}")` — a small parser for a keystroke script string
+- `getText()` / `getDataValue()` / `getOnChangePayload()`
+- **`getCaretOffset()`** — caret position as a character offset into the editor's
+  textContent, read via `page.evaluate` over `window.getSelection()`. This is the
+  single most valuable assertion in the suite and the one happy-dom cannot give you.
+- `expectModelState({ text, dataValue, caret })` — one call, three assertions
+- `pasteHTML(html)` / `pasteText(str)` — via `clipboardData` on a dispatched event
+  **and** a real OS-clipboard variant (`page.evaluate` + `navigator.clipboard.write`
+  with clipboard permissions granted), because those two paths differ
+
+### 4. `e2e/spec/` — the documented behaviour, mirrored
+
+Derive spec files from the docs, one per page in `packages/docs/content/docs/`:
+`basic-usage`, `chips`, `keyboard-navigation`, `onchange`, `options`, `props`,
+`accessibility`, `styling`. **The docs are the spec** — this both tests the library
+and catches documentation drift.
+
+Aim for ~30 specs total. Cover at minimum:
+
+- type text → modal opens on trigger, filters as you type, closes on non-match
+- ArrowUp/Down wrap, Enter selects, Tab selects, Escape closes and stays closed
+- click-outside closes
+- **caret lands immediately after the chip** following selection (v1's `setTimeout`
+  refocus makes this fragile — pin it)
+- Backspace at a chip boundary deletes the whole chip, not part of it
+- Enter inserts a newline when the modal is closed; Shift+Enter behaviour
+- placeholder shows when empty, and **after** clearing a controlled `dataValue`
+- controlled `dataValue` round-trip: set → render → edit → `onChange` → set again
+- paste of plain text, of HTML containing chips, and over a selection
+- option with a function `value` fires the function and removes the trigger
+- native undo (Ctrl/Cmd+Z) after typing and after a chip insert
+- the a11y contract: `role="combobox"`, `aria-expanded`, `aria-activedescendant`
+  tracking the highlighted option
+
+Mark anything currently broken `test.fixme("…")` with a one-line explanation. **Do not
+fix it.**
+
+### 5. `e2e/regressions/` + the recurring workflow — important
+
+This is the part that must keep working for months. The user will frequently say, in
+the middle of unrelated work:
+
+> "add an e2e test to prevent this in future"
+
+That sentence must have a single, boring, deterministic outcome. Set it up:
+
+- create `e2e/regressions/` with a `_template.spec.ts`
+- convention: one file per bug, named `<short-kebab-slug>.spec.ts`, opening with a
+  header comment giving the symptom in one line, the commit or issue that fixed it,
+  and the date
+- each file is **one focused test** reproducing the bug through user actions only —
+  no internal imports, no reaching into hooks
+- write `e2e/README.md` documenting the layering table above, the fixture API, how to
+  run a single spec, how to debug with `--ui` and traces, and — spelled out
+  explicitly — **the recipe for "add an e2e test to prevent this in future"**:
+  reproduce it at the E2E layer if it involves caret/native editing/clipboard,
+  otherwise push it down to unit or component and say so.
+- there is a `CLAUDE.md` in the repo root (gitignored, so local-only). If it exists,
+  add a short `## E2E tests` section pointing at `e2e/README.md` and stating the
+  regression convention, so future sessions pick it up without being told. If it does
+  not exist, say so in your summary rather than creating one.
+
+### 6. CI
+
+Add `.github/workflows/e2e.yml`:
+
+- on PR: chromium only, sharded if it's slow, with the report uploaded as an artifact
+- nightly cron: all browsers plus the mobile project
+- cache Playwright browsers by version
+
+Leave `unit-test.yml` alone.
+
+## Definition of done
+
+- `pnpm test:e2e` passes locally on chromium from a clean `pnpm install`
+- `pnpm --filter mentis test` (vitest) still passes, untouched
+- `git diff main --stat` shows **zero** changes under `packages/mentis/src/`
+- `e2e/README.md` explains the layering and the regression recipe well enough that a
+  future session needs no other context
+- your final summary lists every `test.fixme` you added, each with the bug it pins —
+  that list is the bug backlog
+
+## How to work
+
+Land it in reviewable commits: (1) Playwright install + config + harness page,
+(2) fixtures, (3) spec suite, (4) regressions scaffold + README, (5) CI. Get one
+trivial spec genuinely passing before writing the other twenty-nine — a green
+end-to-end loop first, breadth second.

--- a/e2e/CLAUDE.md
+++ b/e2e/CLAUDE.md
@@ -1,0 +1,15 @@
+# mentis e2e — Playwright suite for a contentEditable library
+
+- **Never modify `packages/mentis/src/` from this directory.** A spec that reveals a library bug gets `test.fixme()` and a one-line comment naming the cause, not a fix. This layer's only job is to be a trustworthy observer; editing source so specs pass repeats commit `a6fcfd0`, where production code was bent to satisfy the test environment.
+- **`test.fixme` bodies assert what *should* happen, not what currently does.** Un-fixme the spec in the same commit as the fix and it becomes the regression test for free.
+- **Caret, native editing and clipboard are asserted here and nowhere else.** A caret assertion in `packages/mentis/tests/` (vitest + happy-dom) is either wrong or accidentally passing. The converse also binds: a bug needing none of the three belongs in vitest — push it down and say that is what you did rather than reaching for a browser.
+- **`textContent` and `displayValue` are allowed to disagree.** `getText()` reads the DOM, `getDisplayValue()` reads the library's model, and several known bugs live only in the gap between them. Assert both; do not tidy a spec by dropping one.
+- **Caret offsets are not portable across a newline.** Firefox inserts a literal `"\n"` that counts in `textContent`; Chromium and WebKit end the line with a block boundary that does not. Use `expectCaretAtEnd()` once content contains a newline — a hard-coded offset there fails on one engine and reads as a library bug.
+- **Firefox drops `clipboardData` from a constructed `ClipboardEvent`.** `pasteText`/`pasteHTML` cannot run there at all; use `pasteByCopying()` for any paste spec that should cover the matrix. This is a limit of the test path, not a library defect — do not report it as one.
+- **Never assert against the demo playground** (`packages/mentis/playground/src/App.tsx`). It is a scratchpad that changes freely. Specs drive `playground/e2e.html` only.
+- **Harness cases are asserted against by id.** Add a case plus its entry in the `CaseId` union rather than bending an existing one to fit a new spec — other specs depend on its current shape.
+- **The harness serves on port 5273, not vite's 5173**, so a suite run can never attach to a demo playground left open during development. Keep it off the default port.
+- **`e2e/spec/` mirrors `packages/docs/content/docs/`, one file per page** — the docs are the spec, which is what makes documentation drift fail the build. Change documented behaviour and the matching spec changes in the same commit.
+- **`_template.spec.ts` is excluded from runs deliberately** and covered by `pnpm typecheck:e2e` instead. It exists to be copied; do not "fix" it by adding it to the suite.
+- **"Add an e2e test to prevent this in future" has exactly one outcome:** one file at `e2e/regressions/<symptom-slug>.spec.ts`, one test, reproduced through user actions only, asserting state *and* caret. Confirm it goes red against the pre-fix code before trusting it.
+- Full recipe, fixture API and the current `test.fixme` backlog are in `e2e/README.md`. Read it before adding a spec.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,325 @@
+# mentis e2e tests
+
+Playwright suite driving `MentionInput` in real browsers.
+
+## Why this layer exists
+
+mentis is a contentEditable library. Its behaviour *is* caret position,
+`Selection`/`Range`, native editing and the clipboard. The vitest + happy-dom
+tests in `packages/mentis/tests/` only approximate all four.
+
+There is direct evidence of the cost in the history: commit `a6fcfd0`, _"fix:
+insert Enter newlines without execCommand in test DOMs"_ — a change to production
+code made to satisfy the fake DOM, not to fix anything for a user. When the test
+environment dictates production code, the environment has stopped being a source
+of truth.
+
+So the rule is: **anything that depends on a real caret is asserted here, and
+nowhere else.**
+
+## Which layer owns what
+
+| Layer         | Tool                    | Owns                                                                            | Must **not** assert                          |
+| ------------- | ----------------------- | ------------------------------------------------------------------------------- | -------------------------------------------- |
+| Unit          | vitest, no DOM          | pure functions: trigger detection, offset math, parsing                         | anything needing a real caret                |
+| Component     | vitest + happy-dom      | props → callbacks → rendered output contract                                    | caret position, native editing, clipboard    |
+| **E2E** (new) | Playwright, real browsers | caret after every operation, native editing, undo/redo, clipboard, IME, mobile, the a11y tree | — |
+
+If you are about to assert a caret position in happy-dom, stop: it is either
+wrong or accidentally passing. Bring it here.
+
+## Running
+
+```sh
+pnpm install
+pnpm exec playwright install          # once, downloads the browsers
+
+pnpm test:e2e                         # all four projects
+pnpm test:e2e:chromium                # just chromium — the fast loop
+pnpm test:e2e:ui                      # interactive, time-travel debugging
+pnpm typecheck:e2e                    # tsc over e2e/ and playwright.config.ts
+```
+
+Narrowing down:
+
+```sh
+pnpm exec playwright test e2e/spec/chips.spec.ts                  # one file
+pnpm exec playwright test e2e/spec/chips.spec.ts:42               # one spec by line
+pnpm exec playwright test -g "Backspace at the chip boundary"     # one spec by name
+pnpm exec playwright test --project=firefox --headed --debug      # watch it happen
+```
+
+When something fails in CI, download the `playwright-report` artifact and open
+it, or run `pnpm test:e2e:report` locally. Traces are captured on first retry;
+open one with `pnpm exec playwright show-trace <path-to-trace.zip>` for a
+DOM snapshot at every step.
+
+The suite boots its own dev server (`pnpm --filter mentis playground:e2e`) on
+**port 5273** — not vite's default 5173, so a run can never accidentally attach
+to a demo playground you already have open. Locally the server is reused if it is
+already up.
+
+## The harness page
+
+Specs run against `packages/mentis/playground/e2e.html`
+(`playground/src/E2EHarness.tsx`), **not** the demo playground. `App.tsx` is a
+scratchpad that changes freely; tests must not depend on it.
+
+Never assert against the demo playground.
+
+The harness renders one `MentionInput` per meaningful prop configuration. Each is
+wrapped in `<section data-testid="mention-<id>">` and paired with
+`<pre data-testid="<id>-onchange">` holding `{"count":n,"data":MentionData|null}`.
+The count lets a spec wait for the *next* payload instead of racing the current
+one.
+
+Case ids are a TypeScript union (`CaseId` in `fixtures/harness.ts`), so a typo is
+a compile error rather than a timeout. Adding a case means adding it there too.
+
+## The fixture API
+
+Every spec starts the same way:
+
+```ts
+import { test, expect } from "../fixtures/harness";
+
+test("...", async ({ harness }) => {
+  const input = harness.case("default");
+  // ...
+});
+```
+
+`harness.case(id)` returns a `MentionCase`. If you find yourself writing
+`page.evaluate` in a spec, a helper is missing — add it to the fixture so the
+next spec gets it for free.
+
+**Locators** — `section`, `editor`, `modal`, `options`, `option(label, nth?)`,
+`highlightedOption`, `noOptions`, `chips`, `outside`.
+
+**Reading state** — `getText()` (the editor's `textContent`), `getHTML()`,
+`getOnChangePayload()`, `getDataValue()`, `getDisplayValue()`, `getMentions()`,
+`getChangeCount()`, `getControlledDataValue()`, `isFocused()`,
+`isCaretCollapsed()`.
+
+**`getCaretOffset()`** — the caret as a character offset into the editor's
+`textContent`, read from `window.getSelection()`. This is the single most
+valuable assertion in the suite and the one happy-dom cannot give you. It returns
+`null` when the caret is not inside the editor, which is usually a focus bug, so
+it is reported rather than coerced to a number.
+
+**Driving** — `focus()` (places the caret at the end, so tests never depend on
+glyph metrics), `typeText(str)` (real key events, never `fill()`),
+`pressKeys(script)`, `undo()`, `redo()`, `selectAll()`.
+
+`pressKeys` runs a keystroke script: literal characters are typed, `{...}` is
+pressed. Playwright key syntax works inside the braces.
+
+```ts
+await input.pressKeys("@al{ArrowDown}{Enter}"); // type, navigate, select
+await input.pressKeys("{Backspace*3}");         // repeat
+await input.pressKeys("{Shift+Enter}");         // modifiers
+await input.pressKeys(`{${MODIFIER}+z}`);       // Meta on macOS, Control elsewhere
+```
+
+**Caret placement** — `setCaretOffset(n)`, `setCaretToStart()`,
+`setCaretToEnd()`, `setCaretBeforeChip(i)`, `setCaretAfterChip(i)`,
+`selectRange(start, end)`. Prefer the chip-relative helpers when a chip boundary
+is the point of the test: an offset that lands on a boundary is ambiguous, those
+are not.
+
+**Clipboard** — three paths, because they are genuinely different code paths in
+the browser and a library that only works under one of them is broken:
+
+| Helper                          | What it does                                            | Where it runs   |
+| ------------------------------- | ------------------------------------------------------- | --------------- |
+| `pasteText` / `pasteHTML`       | dispatches a `ClipboardEvent` carrying a `DataTransfer`  | not Firefox¹    |
+| `pasteByCopying({text\|html})`  | a genuine copy from the harness, then a genuine paste    | everywhere      |
+| `pasteFromSystemClipboard(text)` | `navigator.clipboard.writeText`, then a real paste key  | Chromium only²  |
+
+¹ Firefox ignores `clipboardData` passed to the `ClipboardEvent` constructor, so
+`event.clipboardData` arrives null. That is a limit of the test path, not the
+library. ² Clipboard permissions are only grantable in Chromium through
+Playwright.
+
+Reach for `pasteByCopying` when a paste spec should run on the whole matrix.
+
+**Assertions** — `expectModelState({ text, displayValue, dataValue, caret })` is
+one call for four assertions, and every field is optional. All of them poll, so
+it is safe to call immediately after an action even though `handleSelect`
+refocuses on a `setTimeout`.
+
+```ts
+await input.expectModelState({
+  text: "hi @Alice ",   // what the DOM says
+  displayValue: "hi @Alice ", // what onChange reported the user sees
+  dataValue: "hi alice ",     // what onChange reported the data is
+  caret: 10,
+});
+```
+
+Also `expectCaretOffset(n)`, `expectCaretAtEnd()`, `expectOptionLabels([...])`.
+
+### Two cross-browser traps
+
+**Caret offsets are not portable across a newline.** Chromium and WebKit end a
+line with a block boundary that contributes nothing to `textContent`; Firefox
+inserts a literal `"\n"` that does. The caret is visibly in the same place, but
+its offset differs by one per newline. Use `expectCaretAtEnd()` for content
+containing newlines — a hard-coded offset there asserts a browser quirk, not the
+library.
+
+**`textContent` and `displayValue` are allowed to disagree**, and asserting both
+is the point. `displayValue` is the library's model of the content; `textContent`
+is what is actually in the DOM. Several of the bugs listed below were found
+precisely because the two diverged.
+
+## Layout of this directory
+
+```
+e2e/
+  fixtures/harness.ts     page object + the `test` fixture
+  spec/                   one file per docs page — the docs are the spec
+  regressions/            one file per fixed bug
+  tsconfig.json
+```
+
+`spec/` mirrors `packages/docs/content/docs/` one-to-one: `basic-usage`, `chips`,
+`keyboard-navigation`, `onchange`, `options`, `props`, `accessibility`,
+`styling`. **The docs are the spec** — this both tests the library and catches
+documentation drift. If you change documented behaviour, the matching spec file
+should change in the same commit.
+
+`spec/native-editing.spec.ts` is the exception: it has no counterpart in the
+docs. That is worth noticing rather than tidying away — undo/redo and caret
+cooperation with the browser are where contentEditable libraries die, and none of
+it is currently documented, so there is no stated contract to mirror.
+
+## "Add an e2e test to prevent this in future"
+
+This has one boring, deterministic outcome. Follow it exactly.
+
+### 1. Decide the layer first
+
+Does reproducing the bug require **a real caret, native editing, or the
+clipboard**?
+
+- **Yes** → it belongs here. Continue.
+- **No** → it belongs in `packages/mentis/tests/` as a unit or component test.
+  **Say so out loud** rather than silently putting it in the wrong place: "this
+  one doesn't need a browser — it's offset arithmetic, so it goes in
+  `tests/utils/`." A pure-function bug pinned by a browser test is a slow test
+  that will be deleted in six months.
+
+Rules of thumb for "yes": the bug involves where the cursor ended up, Backspace
+or Delete near a chip, Enter and newlines, undo/redo, paste, focus, IME, mobile,
+or anything where the DOM and the reported model disagreed.
+
+### 2. Write exactly one file
+
+`e2e/regressions/<short-kebab-slug>.spec.ts`, copied from `_template.spec.ts`,
+opening with:
+
+```ts
+/**
+ * Symptom: caret jumped to the start of the input after pressing Enter
+ * Fixed by: a1b2c3d
+ * Date: 2026-08-06
+ */
+```
+
+One bug per file. One test per file. Name the file after the symptom, not the
+cause — the cause is what the fix changed, and you want the file to still make
+sense if the fix is later replaced.
+
+### 3. Reproduce it through user actions only
+
+Key presses, clicks, pastes. No imports from `packages/mentis/src`, no reaching
+into hooks, no calling internals. If it cannot be reproduced that way it is not
+an e2e test — go back to step 1.
+
+Assert **state and caret**. A regression that leaves the right text with the
+caret in the wrong place is still a regression, and the caret is the entire
+reason this layer exists.
+
+### 4. Watch it fail before you trust it
+
+Check out the commit before the fix, or revert the fix in your working tree, and
+confirm the spec goes red. A regression test that has never failed is only
+decoration.
+
+### 5. If the harness needs a new case
+
+Add it to `E2EHarness.tsx`, add its id to the `CaseId` union, and keep the
+`data-testid` convention. Do not bend an existing case to fit — other specs
+assert against it.
+
+## Do not fix bugs from this directory
+
+This branch is testing infrastructure only. When a spec reveals a bug in
+`packages/mentis/src/`, pin it with `test.fixme()` and a comment giving the
+cause, and leave the source alone. The fixme list is the bug backlog:
+
+```sh
+grep -rn "test.fixme" e2e/
+```
+
+Un-fixme the spec in the same commit as the fix, and it becomes the regression
+test for free.
+
+### Current backlog (15)
+
+Found while writing this suite. Each has the cause in a comment above it.
+
+**Data corruption**
+
+- `chips.spec.ts` — pasting text whose mention is not at offset 0 duplicates the
+  leading text and creates no chips at all. `parseMentionsInText` appends the
+  text before a match and then skips chip creation entirely without advancing
+  `lastIndex`. Pasting `"hey @Alice and @Bob"` yields
+  `"hey hey @Alice and hey @Alice and @Bob"`. The worst one here.
+- `chips.spec.ts` — `autoConvertMentions` writes the label into `data-value`
+  instead of the option's value, so the chip looks right and the data is wrong.
+- `options.spec.ts` — option values where one is a prefix of another collide in
+  `reconstructFromDataValue`: `"user10"` matches the option valued `"user1"` and
+  the leftover `"0"` is rendered as text.
+- `onchange.spec.ts` — emptying the editor reports `"\n"` rather than `""`,
+  because the browser's filler `<br>` is counted before it is stripped.
+
+**Caret and editing**
+
+- `native-editing.spec.ts` — typing immediately before a chip destroys it,
+  taking the typed character with it.
+- `props.spec.ts` — controlled `displayValue` resets the caret to offset 0 once
+  the content contains a newline, so the next character lands at the *start* of
+  the input.
+- `native-editing.spec.ts` — native undo cannot revert a chip insertion; the
+  typed query is gone and unrecoverable.
+- `onchange.spec.ts` — one Enter is reported as two newlines.
+
+**Documented but not true**
+
+- `props.spec.ts` — multi-character triggers (`"::"`) never match anything;
+  `detectMentionTrigger` hard-codes a one-character trigger. props.mdx documents
+  them explicitly.
+- `keyboard-navigation.spec.ts` — `onKeyDown` never receives Enter, even with the
+  modal closed, so the form-submission pattern in props.mdx cannot be
+  implemented.
+- `chips.spec.ts` — chips inserted from the dropdown are
+  `contenteditable="true"`; chips.mdx says `false`, and chips restored from
+  `dataValue` are `false`. This is the root cause of the typing-before-a-chip bug
+  above.
+- `keyboard-navigation.spec.ts` — Escape does not close the modal when no options
+  match.
+- `keyboard-navigation.spec.ts` — Escape's dismissal does not stick: the next
+  keystroke reopens the modal without a new trigger.
+- `styling.spec.ts` — `container` and `option` classNames *replace* the default
+  class while the others extend it. For the container that is a functional break:
+  the default class supplies the `position: relative` the dropdown is positioned
+  against.
+- `onchange.spec.ts` — `autoConvertMentions` never fires `onChange` for the
+  conversion it performs, so it is invisible to the consumer.
+
+Two documentation errors found that are not code bugs: chips.mdx's chip-deletion
+example (`Result: "@John DoeX"`) contradicts its own prose, and chips.mdx passes
+`chipClassName` as a top-level prop in one snippet where it belongs in
+`slotsProps`.

--- a/e2e/fixtures/harness.ts
+++ b/e2e/fixtures/harness.ts
@@ -503,7 +503,8 @@ export class MentionCase {
    * press the paste shortcut so the browser builds the event itself.
    *
    * Requires clipboard permissions, which only Chromium grants through
-   * Playwright — guard calls with `test.skip(browserName !== "chromium")`.
+   * Playwright — guard calls with `test.skip(browserName !== "chromium")`. Use
+   * `pasteByCopying` for a real paste that works in every browser.
    */
   async pasteFromSystemClipboard(text: string): Promise<void> {
     await this.ensureFocused();
@@ -511,6 +512,32 @@ export class MentionCase {
       (text) => navigator.clipboard.writeText(text),
       text
     );
+    await this.page.keyboard.press(`${MODIFIER}+v`);
+  }
+
+  /**
+   * Paste by actually copying: fill the harness's copy-source element, select
+   * it, press copy, then press paste in this editor.
+   *
+   * Slower than the other two paths but the most faithful and the only one that
+   * works in every browser — it needs no permissions and no synthetic event, so
+   * the clipboard carries both `text/plain` and `text/html` exactly as it would
+   * for a user. This is the path to reach for when a paste spec should run on the
+   * full matrix.
+   */
+  async pasteByCopying(content: { text?: string; html?: string }): Promise<void> {
+    const source = this.page.getByTestId("clipboard-source");
+
+    await source.evaluate((element, { text, html }) => {
+      if (html !== undefined) element.innerHTML = html;
+      else element.textContent = text ?? "";
+    }, content);
+
+    await source.click();
+    await this.page.keyboard.press(`${MODIFIER}+a`);
+    await this.page.keyboard.press(`${MODIFIER}+c`);
+
+    await this.focus();
     await this.page.keyboard.press(`${MODIFIER}+v`);
   }
 
@@ -554,6 +581,33 @@ export class MentionCase {
         message: `${this.id}: caret offset into textContent`,
       })
       .toBe(offset);
+  }
+
+  /**
+   * Assert the caret sits at the very end of the content, without naming an
+   * offset.
+   *
+   * Use this instead of `expectCaretOffset` whenever the content contains a
+   * newline. Browsers do not agree on how a newline is represented in the DOM —
+   * Chromium and WebKit end the line with a block boundary that contributes
+   * nothing to `textContent`, while Firefox inserts a literal "\n" character
+   * that does. The caret is in the same visible place in both, but its offset
+   * into `textContent` differs by one per newline, so a hard-coded offset would
+   * be asserting a browser quirk rather than the library's behaviour.
+   */
+  async expectCaretAtEnd(): Promise<void> {
+    await expect
+      .poll(
+        async () => {
+          const [caret, text] = await Promise.all([
+            this.getCaretOffset(),
+            this.getText(),
+          ]);
+          return caret === null ? null : caret - text.length;
+        },
+        { message: `${this.id}: caret distance from the end of textContent` }
+      )
+      .toBe(0);
   }
 
   /** Assert the modal is open and listing exactly these option labels, in order. */

--- a/e2e/fixtures/harness.ts
+++ b/e2e/fixtures/harness.ts
@@ -1,0 +1,596 @@
+import {
+  test as base,
+  expect,
+  type Locator,
+  type Page,
+} from "@playwright/test";
+
+/**
+ * Page object + fixtures for the mentis e2e suite.
+ *
+ * Everything a spec needs should be reachable from here. If a spec starts
+ * reaching into `page.evaluate` on its own, that is a signal a helper is
+ * missing — add it here instead, so the next spec gets it for free.
+ *
+ * See e2e/README.md for the layering rules.
+ */
+
+/**
+ * The cases rendered by `packages/mentis/playground/src/E2EHarness.tsx`.
+ * Typed as a union so a typo is a compile error rather than a timeout.
+ */
+export type CaseId =
+  | "default"
+  | "controlled"
+  | "display-value"
+  | "no-trigger"
+  | "auto-convert"
+  | "custom-trigger"
+  | "multi-char-trigger"
+  | "function-value"
+  | "custom-keydown"
+  | "prefix-values"
+  | "placeholder"
+  | "styled";
+
+/** The shared option list rendered by every case except `prefix-values`. */
+export const OPTION_LABELS = [
+  "Alice",
+  "Bob",
+  "Charlie",
+  "Dave",
+  "Erin",
+  "Erin",
+] as const;
+
+/** Chips are identified by their data attributes, not their class — the class is
+ * configurable via `slotsProps.chipClassName` but the data attributes are the
+ * documented contract (see docs/chips.mdx). */
+const CHIP_SELECTOR = "[data-value][data-label]";
+
+/** `Meta` on macOS, `Control` elsewhere. Browsers run on the host OS, so the
+ * host platform is the right thing to key off. */
+export const MODIFIER = process.platform === "darwin" ? "Meta" : "Control";
+
+/** A slower-than-instant keystroke cadence. Real typing is not a burst, and the
+ * library does work on every `input` event; typing with no delay at all hides
+ * ordering bugs that users hit. */
+const TYPE_DELAY = 15;
+
+export type ChangeLog = {
+  count: number;
+  data: {
+    displayValue: string;
+    dataValue: string;
+    mentions: Array<{
+      label: string;
+      value: string;
+      startIndex: number;
+      endIndex: number;
+    }>;
+  } | null;
+};
+
+export type ModelState = {
+  /** The editor's `textContent` — what the user sees, newlines included. */
+  text?: string;
+  /** `dataValue` from the most recent `onChange` payload. */
+  dataValue?: string;
+  /** `displayValue` from the most recent `onChange` payload. */
+  displayValue?: string;
+  /** Caret position as a character offset into the editor's `textContent`. */
+  caret?: number;
+};
+
+export class MentionCase {
+  constructor(
+    readonly page: Page,
+    readonly id: CaseId
+  ) {}
+
+  // --- locators ------------------------------------------------------------
+
+  /** The wrapper the harness puts around this case. Every other locator is
+   * scoped to it, so cases cannot interfere with each other. */
+  get section(): Locator {
+    return this.page.getByTestId(`mention-${this.id}`);
+  }
+
+  get editor(): Locator {
+    return this.section.getByRole("combobox");
+  }
+
+  get modal(): Locator {
+    return this.section.getByRole("listbox");
+  }
+
+  get options(): Locator {
+    return this.modal.getByRole("option");
+  }
+
+  /** The 'No items found' element. */
+  get noOptions(): Locator {
+    return this.modal.locator(".mention-no-options, .harness-no-options");
+  }
+
+  get chips(): Locator {
+    return this.editor.locator(CHIP_SELECTOR);
+  }
+
+  option(label: string, nth = 0): Locator {
+    return this.options.filter({ hasText: label }).nth(nth);
+  }
+
+  /** The option the component reports as highlighted, via `aria-selected`. */
+  get highlightedOption(): Locator {
+    return this.options.and(this.page.locator("[aria-selected=true]"));
+  }
+
+  /** A click target outside the editor, positioned above it so an open modal
+   * cannot cover it. */
+  get outside(): Locator {
+    return this.page.getByTestId(`${this.id}-outside`);
+  }
+
+  // --- reading state -------------------------------------------------------
+
+  /** The editor's `textContent`. Deliberately not `innerText`: `textContent` is
+   * the string the library's own model is built from, so comparing against it
+   * catches divergence between what is rendered and what is reported. */
+  async getText(): Promise<string> {
+    return (await this.editor.textContent()) ?? "";
+  }
+
+  async getHTML(): Promise<string> {
+    return this.editor.innerHTML();
+  }
+
+  async getChangeLog(): Promise<ChangeLog> {
+    const raw =
+      (await this.page.getByTestId(`${this.id}-onchange`).textContent()) ?? "";
+    return JSON.parse(raw) as ChangeLog;
+  }
+
+  /** The most recent `onChange` payload, or null if `onChange` has not fired. */
+  async getOnChangePayload(): Promise<ChangeLog["data"]> {
+    return (await this.getChangeLog()).data;
+  }
+
+  /** How many times `onChange` has fired. Snapshot this before an action to
+   * wait for the *next* payload rather than racing the current one. */
+  async getChangeCount(): Promise<number> {
+    return (await this.getChangeLog()).count;
+  }
+
+  async getDataValue(): Promise<string | null> {
+    return (await this.getOnChangePayload())?.dataValue ?? null;
+  }
+
+  async getDisplayValue(): Promise<string | null> {
+    return (await this.getOnChangePayload())?.displayValue ?? null;
+  }
+
+  async getMentions(): Promise<NonNullable<ChangeLog["data"]>["mentions"]> {
+    return (await this.getOnChangePayload())?.mentions ?? [];
+  }
+
+  /**
+   * The `dataValue` prop the harness is currently feeding back into the
+   * component. Only meaningful for the controlled cases — this is the value
+   * that completes the round trip, as opposed to the one `onChange` emitted.
+   */
+  async getControlledDataValue(): Promise<string> {
+    return (
+      (await this.page.getByTestId(`${this.id}-datavalue`).textContent()) ?? ""
+    );
+  }
+
+  /**
+   * The caret as a character offset into the editor's `textContent`.
+   *
+   * This is the assertion the vitest/happy-dom layer cannot give us, and the
+   * reason this suite exists. Returns null when the caret is not inside this
+   * editor (no selection, or focus is elsewhere) — a null where a number was
+   * expected is usually a focus bug, so it is reported rather than coerced.
+   */
+  async getCaretOffset(): Promise<number | null> {
+    return this.editor.evaluate((editor) => {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return null;
+
+      const range = selection.getRangeAt(0);
+      if (!editor.contains(range.startContainer)) return null;
+
+      const preCaret = range.cloneRange();
+      preCaret.selectNodeContents(editor);
+      preCaret.setEnd(range.endContainer, range.endOffset);
+      return preCaret.toString().length;
+    });
+  }
+
+  /** Whether the caret is a collapsed point rather than a selection. */
+  async isCaretCollapsed(): Promise<boolean | null> {
+    return this.editor.evaluate((editor) => {
+      const selection = window.getSelection();
+      if (!selection || selection.rangeCount === 0) return null;
+      const range = selection.getRangeAt(0);
+      if (!editor.contains(range.startContainer)) return null;
+      return range.collapsed;
+    });
+  }
+
+  async isFocused(): Promise<boolean> {
+    return this.editor.evaluate((editor) => document.activeElement === editor);
+  }
+
+  // --- driving the editor --------------------------------------------------
+
+  /**
+   * Focus the editor, placing the caret at the end of its content.
+   *
+   * Clicking would place the caret wherever the click landed, which makes tests
+   * depend on glyph metrics; this is deliberate and repeatable instead.
+   */
+  async focus(): Promise<void> {
+    await this.editor.click();
+    await this.setCaretToEnd();
+  }
+
+  private async ensureFocused(): Promise<void> {
+    if (!(await this.isFocused())) await this.focus();
+  }
+
+  /**
+   * Type `text` as real key events, one key at a time.
+   *
+   * Not `fill()` and not `insertText`: both skip the keydown/keypress/input
+   * sequence the library actually listens to, which is precisely the part that
+   * a fake DOM already fails to model.
+   */
+  async typeText(text: string): Promise<void> {
+    await this.ensureFocused();
+    await this.page.keyboard.type(text, { delay: TYPE_DELAY });
+  }
+
+  /**
+   * Run a keystroke script.
+   *
+   * Literal characters are typed; `{...}` is pressed as a key. Playwright key
+   * syntax works inside the braces, so modifiers and repeats are available:
+   *
+   *   await case.pressKeys("@al{ArrowDown}{Enter}")
+   *   await case.pressKeys("{Shift+Enter}")
+   *   await case.pressKeys("{Backspace*3}")
+   *   await case.pressKeys(`{${MODIFIER}+z}`)
+   *
+   * To type a literal brace, use `{{}` or `{}}`.
+   */
+  async pressKeys(script: string): Promise<void> {
+    await this.ensureFocused();
+
+    for (const token of script.match(/\{[^}]*\}|\}|[^{]+/g) ?? []) {
+      const isKey = token.startsWith("{") && token.endsWith("}");
+      if (!isKey) {
+        await this.page.keyboard.type(token, { delay: TYPE_DELAY });
+        continue;
+      }
+
+      const body = token.slice(1, -1);
+      if (body === "{" || body === "}" || body === "") {
+        await this.page.keyboard.type(body || "{", { delay: TYPE_DELAY });
+        continue;
+      }
+
+      const repeated = body.match(/^(.+)\*(\d+)$/);
+      const key = repeated ? repeated[1] : body;
+      const times = repeated ? Number(repeated[2]) : 1;
+
+      for (let i = 0; i < times; i++) {
+        await this.page.keyboard.press(key, { delay: TYPE_DELAY });
+      }
+    }
+  }
+
+  /** Native undo. Distinct from anything the library implements — that is the
+   * point: chip insertion must not corrupt the browser's own undo stack. */
+  async undo(): Promise<void> {
+    await this.ensureFocused();
+    await this.page.keyboard.press(`${MODIFIER}+z`);
+  }
+
+  async redo(): Promise<void> {
+    await this.ensureFocused();
+    await this.page.keyboard.press(`${MODIFIER}+Shift+z`);
+  }
+
+  async selectAll(): Promise<void> {
+    await this.ensureFocused();
+    await this.page.keyboard.press(`${MODIFIER}+a`);
+  }
+
+  // --- caret placement ----------------------------------------------------
+
+  /**
+   * Put the caret at a character offset into the editor's `textContent`.
+   *
+   * Resolves to the earliest text node that reaches the offset, so an offset
+   * that falls on a chip boundary lands *inside* the preceding node. Use
+   * `setCaretAfterChip` / `setCaretBeforeChip` when the boundary is the point of
+   * the test — those are unambiguous.
+   */
+  async setCaretOffset(offset: number): Promise<void> {
+    await this.editor.evaluate((editor, target) => {
+      const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+      const range = document.createRange();
+
+      let remaining = target;
+      let node = walker.nextNode();
+      let placed = false;
+
+      while (node) {
+        const length = node.textContent?.length ?? 0;
+        if (remaining <= length) {
+          range.setStart(node, remaining);
+          placed = true;
+          break;
+        }
+        remaining -= length;
+        node = walker.nextNode();
+      }
+
+      // Offset past the end of the content: clamp to the very end.
+      if (!placed) {
+        range.selectNodeContents(editor);
+        range.collapse(false);
+      }
+
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    }, offset);
+  }
+
+  async setCaretToEnd(): Promise<void> {
+    await this.editor.evaluate((editor) => {
+      const range = document.createRange();
+      range.selectNodeContents(editor);
+      range.collapse(false);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+  }
+
+  async setCaretToStart(): Promise<void> {
+    await this.editor.evaluate((editor) => {
+      const range = document.createRange();
+      range.selectNodeContents(editor);
+      range.collapse(true);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+    });
+  }
+
+  /** Caret immediately after chip `index`, in the editor's node order. */
+  async setCaretAfterChip(index = 0): Promise<void> {
+    await this.setCaretRelativeToChip(index, "after");
+  }
+
+  /** Caret immediately before chip `index`. */
+  async setCaretBeforeChip(index = 0): Promise<void> {
+    await this.setCaretRelativeToChip(index, "before");
+  }
+
+  private async setCaretRelativeToChip(
+    index: number,
+    side: "before" | "after"
+  ): Promise<void> {
+    await this.editor.evaluate(
+      (editor, { index, side, selector }) => {
+        const chip = editor.querySelectorAll(selector)[index];
+        if (!chip) throw new Error(`no chip at index ${index}`);
+
+        const range = document.createRange();
+        if (side === "after") range.setStartAfter(chip);
+        else range.setStartBefore(chip);
+        range.collapse(true);
+
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      },
+      { index, side, selector: CHIP_SELECTOR }
+    );
+  }
+
+  /** Select the text between two `textContent` offsets, for paste-over-selection
+   * and typing-over-selection tests. */
+  async selectRange(start: number, end: number): Promise<void> {
+    await this.ensureFocused();
+    await this.editor.evaluate(
+      (editor, { start, end }) => {
+        const walker = document.createTreeWalker(editor, NodeFilter.SHOW_TEXT);
+        const range = document.createRange();
+
+        let offset = 0;
+        let startPlaced = false;
+        let node = walker.nextNode();
+
+        while (node) {
+          const length = node.textContent?.length ?? 0;
+          if (!startPlaced && start <= offset + length) {
+            range.setStart(node, start - offset);
+            startPlaced = true;
+          }
+          if (startPlaced && end <= offset + length) {
+            range.setEnd(node, end - offset);
+            break;
+          }
+          offset += length;
+          node = walker.nextNode();
+        }
+
+        const selection = window.getSelection();
+        selection?.removeAllRanges();
+        selection?.addRange(range);
+      },
+      { start, end }
+    );
+  }
+
+  // --- clipboard -----------------------------------------------------------
+
+  /**
+   * Paste plain text by dispatching a `paste` event carrying a `DataTransfer`.
+   *
+   * This is the path a synthetic paste takes, and it is *not* the same path as a
+   * real OS paste — see `pasteFromSystemClipboard`. Both are provided because
+   * the two differ, and a library that only works under one of them is broken.
+   */
+  async pasteText(text: string): Promise<void> {
+    await this.ensureFocused();
+    await this.editor.evaluate((editor, text) => {
+      const data = new DataTransfer();
+      data.setData("text/plain", text);
+      editor.dispatchEvent(
+        new ClipboardEvent("paste", {
+          clipboardData: data,
+          bubbles: true,
+          cancelable: true,
+        })
+      );
+    }, text);
+  }
+
+  /**
+   * Paste HTML by dispatching a `paste` event carrying both `text/html` and the
+   * `text/plain` flattening of it — which is what a real browser puts on the
+   * clipboard when you copy rich content.
+   *
+   * Pass `plainText` explicitly when the two should disagree.
+   */
+  async pasteHTML(html: string, plainText?: string): Promise<void> {
+    await this.ensureFocused();
+    await this.editor.evaluate(
+      (editor, { html, plainText }) => {
+        const data = new DataTransfer();
+        data.setData("text/html", html);
+
+        let plain = plainText;
+        if (plain === undefined) {
+          const scratch = document.createElement("div");
+          scratch.innerHTML = html;
+          plain = scratch.textContent ?? "";
+        }
+        data.setData("text/plain", plain);
+
+        editor.dispatchEvent(
+          new ClipboardEvent("paste", {
+            clipboardData: data,
+            bubbles: true,
+            cancelable: true,
+          })
+        );
+      },
+      { html, plainText }
+    );
+  }
+
+  /**
+   * Paste via the real OS clipboard: write it with the async Clipboard API, then
+   * press the paste shortcut so the browser builds the event itself.
+   *
+   * Requires clipboard permissions, which only Chromium grants through
+   * Playwright — guard calls with `test.skip(browserName !== "chromium")`.
+   */
+  async pasteFromSystemClipboard(text: string): Promise<void> {
+    await this.ensureFocused();
+    await this.page.evaluate(
+      (text) => navigator.clipboard.writeText(text),
+      text
+    );
+    await this.page.keyboard.press(`${MODIFIER}+v`);
+  }
+
+  // --- assertions ----------------------------------------------------------
+
+  /**
+   * Assert text, `dataValue`, `displayValue` and caret in one call. Every field
+   * is optional; only what you pass is asserted.
+   *
+   * Each assertion polls, so this is safe to call immediately after an action —
+   * React's re-render and the library's `setTimeout` refocus both settle.
+   */
+  async expectModelState(state: ModelState): Promise<void> {
+    if (state.text !== undefined) {
+      await expect
+        .poll(() => this.getText(), { message: `${this.id}: editor text` })
+        .toBe(state.text);
+    }
+    if (state.dataValue !== undefined) {
+      await expect
+        .poll(() => this.getDataValue(), {
+          message: `${this.id}: onChange dataValue`,
+        })
+        .toBe(state.dataValue);
+    }
+    if (state.displayValue !== undefined) {
+      await expect
+        .poll(() => this.getDisplayValue(), {
+          message: `${this.id}: onChange displayValue`,
+        })
+        .toBe(state.displayValue);
+    }
+    if (state.caret !== undefined) {
+      await this.expectCaretOffset(state.caret);
+    }
+  }
+
+  async expectCaretOffset(offset: number): Promise<void> {
+    await expect
+      .poll(() => this.getCaretOffset(), {
+        message: `${this.id}: caret offset into textContent`,
+      })
+      .toBe(offset);
+  }
+
+  /** Assert the modal is open and listing exactly these option labels, in order. */
+  async expectOptionLabels(labels: readonly string[]): Promise<void> {
+    await expect(this.modal).toBeVisible();
+    await expect(this.options).toHaveText([...labels]);
+  }
+}
+
+export class Harness {
+  private readonly cases = new Map<CaseId, MentionCase>();
+
+  constructor(readonly page: Page) {}
+
+  case(id: CaseId): MentionCase {
+    const existing = this.cases.get(id);
+    if (existing) return existing;
+
+    const created = new MentionCase(this.page, id);
+    this.cases.set(id, created);
+    return created;
+  }
+}
+
+export const test = base.extend<{ harness: Harness }>({
+  harness: async ({ page, context, browserName }, use) => {
+    if (browserName === "chromium") {
+      // Only Chromium supports these through Playwright; the specs that need a
+      // real OS paste skip elsewhere.
+      await context
+        .grantPermissions(["clipboard-read", "clipboard-write"])
+        .catch(() => {});
+    }
+
+    await page.goto("/e2e.html");
+    await use(new Harness(page));
+  },
+});
+
+export { expect };

--- a/e2e/regressions/_template.spec.ts
+++ b/e2e/regressions/_template.spec.ts
@@ -1,0 +1,33 @@
+/**
+ * Symptom: <one line, in user terms — what the person saw, not the cause>
+ * Fixed by: <commit sha, PR or issue link>
+ * Date: <YYYY-MM-DD>
+ *
+ * Copy this file to `<short-kebab-slug>.spec.ts` and delete this paragraph.
+ * One bug per file, one test per file. Reproduce it the way the user hit it:
+ * key presses, clicks and pastes only — no imports from packages/mentis/src, no
+ * reaching into hooks, no calling internals. If the bug cannot be reproduced
+ * that way, it probably belongs in a unit or component test instead; see the
+ * "add an e2e test to prevent this in future" section of e2e/README.md.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("the thing that broke does not break again", async ({ harness }) => {
+  const input = harness.case("default");
+
+  // Arrange: get the editor into the state the bug needed.
+  await input.typeText("hi @al");
+
+  // Act: the single user action that used to go wrong.
+  await input.pressKeys("{Enter}");
+
+  // Assert: state *and* caret. A regression that leaves the right text with the
+  // caret in the wrong place is still a regression, and the caret is the reason
+  // this layer exists.
+  await input.expectModelState({
+    text: "hi @Alice ",
+    dataValue: "hi alice ",
+    caret: 10,
+  });
+  await expect(input.chips).toHaveCount(1);
+});

--- a/e2e/spec/accessibility.spec.ts
+++ b/e2e/spec/accessibility.spec.ts
@@ -1,0 +1,89 @@
+/**
+ * Mirrors docs/content/docs/accessibility.mdx — the ARIA contract.
+ *
+ * These are cheap assertions that break loudly, which is exactly what you want
+ * from an a11y contract: nothing else in the suite would notice if
+ * aria-activedescendant silently stopped tracking.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("the editor exposes the documented combobox attributes", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await expect(input.editor).toHaveAttribute("role", "combobox");
+  await expect(input.editor).toHaveAttribute("aria-autocomplete", "list");
+  await expect(input.editor).toHaveAttribute("aria-haspopup", "listbox");
+  await expect(input.editor).toHaveAttribute("aria-expanded", "false");
+  await expect(input.editor).not.toHaveAttribute("aria-controls", /.*/);
+});
+
+test("aria-expanded and aria-controls track the modal", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@al");
+
+  await expect(input.editor).toHaveAttribute("aria-expanded", "true");
+  await expect(input.editor).toHaveAttribute("aria-controls", "mention-modal");
+  await expect(input.modal).toHaveAttribute("role", "listbox");
+  await expect(input.modal).toHaveAttribute("id", "mention-modal");
+
+  await input.pressKeys("{Escape}");
+
+  await expect(input.editor).toHaveAttribute("aria-expanded", "false");
+  await expect(input.editor).not.toHaveAttribute("aria-controls", /.*/);
+});
+
+test("aria-activedescendant follows the highlighted option", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+  await expect(input.editor).toHaveAttribute(
+    "aria-activedescendant",
+    "mention-option-alice"
+  );
+
+  await input.pressKeys("{ArrowDown}");
+
+  await expect(input.editor).toHaveAttribute(
+    "aria-activedescendant",
+    "mention-option-charlie"
+  );
+  // The id it points at must exist, and be the one marked selected.
+  await expect(input.page.locator("#mention-option-charlie")).toHaveAttribute(
+    "aria-selected",
+    "true"
+  );
+});
+
+test("exactly one option is aria-selected at a time", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+
+  await expect(input.highlightedOption).toHaveCount(1);
+  await expect(input.options).toHaveCount(3);
+
+  await input.pressKeys("{ArrowDown}");
+
+  await expect(input.highlightedOption).toHaveCount(1);
+});
+
+test("aria-activedescendant is absent when nothing matches", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("@zz");
+
+  // The modal is open with a "No items found" message, so it must not claim an
+  // active option — there is no element with that id to point at.
+  await expect(input.editor).toHaveAttribute("aria-expanded", "true");
+  await expect(input.editor).not.toHaveAttribute(
+    "aria-activedescendant",
+    /.*/
+  );
+});

--- a/e2e/spec/basic-usage.spec.ts
+++ b/e2e/spec/basic-usage.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Mirrors docs/content/docs/basic-usage.mdx.
+ *
+ * The documented shape is: give it `options`, a controlled `dataValue`, and an
+ * `onChange` that feeds `dataValue` back in. These specs check that loop closes.
+ */
+import { test, expect, OPTION_LABELS } from "../fixtures/harness";
+
+test("typing the trigger opens the modal listing every option", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await expect(input.modal).toBeHidden();
+  await input.typeText("@");
+
+  await input.expectOptionLabels(OPTION_LABELS);
+});
+
+test("plain text is reported through onChange without any mentions", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("hi there");
+
+  await input.expectModelState({
+    text: "hi there",
+    displayValue: "hi there",
+    dataValue: "hi there",
+    caret: 8,
+  });
+  expect(await input.getMentions()).toEqual([]);
+});

--- a/e2e/spec/basic-usage.spec.ts
+++ b/e2e/spec/basic-usage.spec.ts
@@ -1,8 +1,8 @@
 /**
  * Mirrors docs/content/docs/basic-usage.mdx.
  *
- * The documented shape is: give it `options`, a controlled `dataValue`, and an
- * `onChange` that feeds `dataValue` back in. These specs check that loop closes.
+ * The documented shape is: pass `options`, hold `dataValue` in state, and feed
+ * it back from `onChange`. These specs check that loop closes.
  */
 import { test, expect, OPTION_LABELS } from "../fixtures/harness";
 
@@ -31,4 +31,49 @@ test("plain text is reported through onChange without any mentions", async ({
     caret: 8,
   });
   expect(await input.getMentions()).toEqual([]);
+});
+
+test("selecting an option replaces the trigger and query with a chip", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("hi @al");
+  await input.expectOptionLabels(["Alice"]);
+  await input.pressKeys("{Enter}");
+
+  await expect(input.chips).toHaveCount(1);
+  await expect(input.chips.first()).toHaveText("@Alice");
+
+  // displayValue carries the label, dataValue carries the value — the
+  // distinction the whole library exists for.
+  await input.expectModelState({
+    text: "hi @Alice ",
+    displayValue: "hi @Alice ",
+    dataValue: "hi alice ",
+  });
+  await expect(input.modal).toBeHidden();
+});
+
+test("the documented controlled loop round-trips a mention", async ({
+  harness,
+}) => {
+  const input = harness.case("controlled");
+
+  await input.pressKeys("@al{Enter}");
+
+  // onChange emitted a dataValue, the harness fed it back in as the prop, and
+  // the component did not fight itself over the result.
+  await expect
+    .poll(() => input.getControlledDataValue())
+    .toBe("alice ");
+  await input.expectModelState({ text: "@Alice ", dataValue: "alice " });
+
+  await input.typeText("hello");
+
+  await input.expectModelState({
+    text: "@Alice hello",
+    dataValue: "alice hello",
+  });
+  await expect(input.chips).toHaveCount(1);
 });

--- a/e2e/spec/chips.spec.ts
+++ b/e2e/spec/chips.spec.ts
@@ -1,0 +1,281 @@
+/**
+ * Mirrors docs/content/docs/chips.mdx — the chip contract, the three documented
+ * ways a chip gets created (selection, auto-conversion, paste), and chip
+ * deletion.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("a chip carries the documented data attributes", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.pressKeys("@al{Enter}");
+
+  const chip = input.chips.first();
+  await expect(chip).toHaveAttribute("data-value", "alice");
+  await expect(chip).toHaveAttribute("data-label", "Alice");
+  await expect(chip).toHaveClass(/mention-chip/);
+  await expect(chip).toHaveText("@Alice");
+});
+
+test("the caret lands after the chip and its inserted space", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("hi @al");
+  await input.pressKeys("{Enter}");
+
+  // "hi @Alice " is 10 characters; the caret belongs at the end of it, ready for
+  // the next word. This is the assertion the happy-dom layer cannot make, and
+  // it is fragile by construction: handleSelect sets the range and *then*
+  // refocuses on a setTimeout.
+  await input.expectModelState({ text: "hi @Alice ", caret: 10 });
+  expect(await input.isCaretCollapsed()).toBe(true);
+  expect(await input.isFocused()).toBe(true);
+});
+
+test("a chip inserted mid-sentence keeps the text after it", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("hi  there");
+  await input.setCaretOffset(3);
+  await input.typeText("@al");
+  await input.pressKeys("{Enter}");
+
+  await input.expectModelState({
+    text: "hi @Alice there",
+    dataValue: "hi alice there",
+  });
+});
+
+test("Backspace at the chip boundary removes the whole chip", async ({
+  harness,
+}) => {
+  const input = harness.case("no-trigger");
+
+  await input.pressKeys("@al{Enter}");
+  await input.expectModelState({ text: "Alice " });
+
+  await input.setCaretAfterChip(0);
+  await input.pressKeys("{Backspace}");
+
+  // The whole chip goes, not the last character of its label.
+  await expect(input.chips).toHaveCount(0);
+  await input.expectModelState({ text: " ", dataValue: " " });
+});
+
+test("typing inside a chip deletes the whole chip", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.pressKeys("@al{Enter}");
+  // Land inside the chip's own text node, between "@Al" and "ice".
+  await input.setCaretOffset(3);
+  await input.typeText("X");
+
+  // docs/chips.mdx describes this as "the chip is deleted, X is not inserted",
+  // which is what happens — the typed character is inside the chip when the
+  // chip is removed, so it goes with it. (The worked example in that page,
+  // 'Result: "@John DoeX"', contradicts its own prose.)
+  await expect(input.chips).toHaveCount(0);
+  await input.expectModelState({ text: " ", dataValue: " " });
+});
+
+test("keepTriggerOnSelect={false} leaves the trigger out of the chip", async ({
+  harness,
+}) => {
+  const input = harness.case("no-trigger");
+
+  await input.pressKeys("@al{Enter}");
+
+  await expect(input.chips.first()).toHaveText("Alice");
+  await input.expectModelState({ text: "Alice ", dataValue: "alice " });
+});
+
+test("chips reconstructed from dataValue are not editable", async ({
+  harness,
+}) => {
+  const input = harness.case("controlled");
+
+  await input.page.getByTestId("controlled-seed").click();
+
+  await expect(input.chips).toHaveCount(1);
+  await expect(input.chips.first()).toHaveAttribute("contenteditable", "false");
+  await expect(input.chips.first()).toHaveAttribute(
+    "data-value",
+    "erin-primary"
+  );
+  await input.expectModelState({ text: "hi @Erin" });
+});
+
+// Bug: docs/chips.mdx states chips are `contenteditable="false"` to protect them
+// from editing, and `reconstructFromDataValue` does emit that. But
+// `insertMentionIntoDOM` sets contentEditable = "true", so a chip created by
+// selecting from the dropdown is editable while an identical chip restored from
+// dataValue is not.
+test.fixme(
+  "a chip inserted from the dropdown is not editable either",
+  async ({ harness }) => {
+    const input = harness.case("default");
+
+    await input.pressKeys("@al{Enter}");
+
+    await expect(input.chips.first()).toHaveAttribute(
+      "contenteditable",
+      "false"
+    );
+  }
+);
+
+// Bug: `convertTextToChips` builds the chip from the matched text rather than
+// from the option, so data-value holds the label ("Alice") instead of the
+// option's value ("alice"). The chip looks right and the data is wrong.
+test.fixme(
+  "autoConvertMentions stores the option value on the chip",
+  async ({ harness }) => {
+    const input = harness.case("auto-convert");
+
+    await input.typeText("@Alice ");
+
+    await expect(input.chips).toHaveCount(1);
+    await expect(input.chips.first()).toHaveAttribute("data-value", "alice");
+    await input.expectModelState({ dataValue: "alice " });
+  }
+);
+
+// --- paste (docs/chips.mdx "3. Paste Operations") -------------------------
+
+/*
+ * Three paste paths, deliberately:
+ *
+ *   pasteText / pasteHTML   dispatch a ClipboardEvent carrying a DataTransfer
+ *   pasteByCopying          a genuine copy from the harness, then a genuine paste
+ *   pasteFromSystemClipboard  navigator.clipboard.writeText, then a genuine paste
+ *
+ * Firefox ignores `clipboardData` passed to the ClipboardEvent constructor, so
+ * `event.clipboardData` arrives null there and the synthetic path cannot run at
+ * all. That is a limitation of the test path, not of the library — so the
+ * synthetic specs skip on Firefox and `pasteByCopying` carries the cross-browser
+ * coverage.
+ */
+const SYNTHETIC_PASTE_UNSUPPORTED =
+  "firefox drops clipboardData from a constructed ClipboardEvent";
+
+test("pasting text whose mention starts at offset 0 creates a chip", async ({
+  harness,
+  browserName,
+}) => {
+  test.skip(browserName === "firefox", SYNTHETIC_PASTE_UNSUPPORTED);
+
+  const input = harness.case("custom-trigger");
+
+  await input.pasteText("#Bob trailing");
+
+  await expect(input.chips).toHaveCount(1);
+  await expect(input.chips.first()).toHaveAttribute("data-value", "bob");
+  await input.expectModelState({
+    text: "#Bob trailing",
+    displayValue: "#Bob trailing",
+    dataValue: "bob trailing",
+  });
+});
+
+// Bug, and the worst one this suite found: in `parseMentionsInText` the
+// "is there text before this match" branch appends that text and then *skips
+// chip creation entirely*, never advancing lastIndex. So every mention that
+// isn't at offset 0 is left as plain text, and the leading text is emitted once
+// per match plus once more at the end. Pasting "hey @Alice and @Bob" yields
+// "hey hey @Alice and hey @Alice and @Bob" with no chips at all.
+test.fixme(
+  "pasting text with a mention after other text creates chips",
+  async ({ harness }) => {
+    const input = harness.case("default");
+
+    await input.pasteByCopying({ text: "hey @Alice and @Bob" });
+
+    await input.expectModelState({
+      text: "hey @Alice and @Bob",
+      dataValue: "hey alice and bob",
+    });
+    await expect(input.chips).toHaveCount(2);
+  }
+);
+
+test("pasting HTML uses the plain-text flavour and re-parses it", async ({
+  harness,
+  browserName,
+}) => {
+  test.skip(browserName === "firefox", SYNTHETIC_PASTE_UNSUPPORTED);
+
+  const input = harness.case("custom-trigger");
+
+  // A real browser puts both flavours on the clipboard when rich content is
+  // copied. The library reads only text/plain, so the incoming chip markup is
+  // discarded and the mention is recognised from the text.
+  await input.pasteHTML(
+    '<span class="mention-chip" data-value="bob" data-label="Bob" contenteditable="false">#Bob</span> hello'
+  );
+
+  await expect(input.chips).toHaveCount(1);
+  await expect(input.chips.first()).toHaveAttribute("data-value", "bob");
+  await input.expectModelState({ text: "#Bob hello", dataValue: "bob hello" });
+});
+
+test("pasting over a selection replaces it", async ({
+  harness,
+  browserName,
+}) => {
+  test.skip(browserName === "firefox", SYNTHETIC_PASTE_UNSUPPORTED);
+
+  const input = harness.case("default");
+
+  await input.typeText("hello world");
+  await input.selectRange(0, 5);
+  await input.pasteText("bye");
+
+  await input.expectModelState({
+    text: "bye world",
+    dataValue: "bye world",
+    caret: 3,
+  });
+});
+
+test("a genuine copy-and-paste creates a chip in every browser", async ({
+  harness,
+}) => {
+  const input = harness.case("custom-trigger");
+
+  // No permissions, no synthetic event: the content goes onto the real clipboard
+  // through a real copy, so this runs on the whole matrix and is the closest
+  // thing in the suite to what a user does.
+  await input.pasteByCopying({ text: "#Bob trailing" });
+
+  await expect(input.chips).toHaveCount(1);
+  await expect(input.chips.first()).toHaveAttribute("data-value", "bob");
+  await input.expectModelState({
+    text: "#Bob trailing",
+    dataValue: "bob trailing",
+  });
+});
+
+test("a real OS paste behaves like a dispatched one", async ({
+  harness,
+  browserName,
+}) => {
+  // Clipboard permissions are only grantable in Chromium through Playwright.
+  test.skip(
+    browserName !== "chromium",
+    "clipboard permissions are chromium-only"
+  );
+
+  const input = harness.case("custom-trigger");
+
+  await input.pasteFromSystemClipboard("#Bob trailing");
+
+  await expect(input.chips).toHaveCount(1);
+  await input.expectModelState({
+    text: "#Bob trailing",
+    dataValue: "bob trailing",
+  });
+});

--- a/e2e/spec/keyboard-navigation.spec.ts
+++ b/e2e/spec/keyboard-navigation.spec.ts
@@ -1,0 +1,208 @@
+/**
+ * Mirrors docs/content/docs/keyboard-navigation.mdx.
+ *
+ * The documented contract: Up/Down move the highlight, Enter or Tab select,
+ * Escape closes, and `onKeyDown` is not called for those keys while the modal is
+ * open.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("ArrowDown moves the highlight down the list", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+  await expect(input.highlightedOption).toHaveText("Alice");
+
+  await input.pressKeys("{ArrowDown}");
+  await expect(input.highlightedOption).toHaveText("Charlie");
+
+  await input.pressKeys("{ArrowDown}");
+  await expect(input.highlightedOption).toHaveText("Dave");
+});
+
+test("ArrowDown wraps from the last option to the first", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+  await input.pressKeys("{ArrowDown*2}");
+  await expect(input.highlightedOption).toHaveText("Dave");
+
+  await input.pressKeys("{ArrowDown}");
+
+  await expect(input.highlightedOption).toHaveText("Alice");
+});
+
+test("ArrowUp wraps from the first option to the last", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+  await expect(input.highlightedOption).toHaveText("Alice");
+
+  await input.pressKeys("{ArrowUp}");
+
+  await expect(input.highlightedOption).toHaveText("Dave");
+});
+
+test("the highlight resets to the first option as the query changes", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+  await input.pressKeys("{ArrowDown}");
+  await expect(input.highlightedOption).toHaveText("Charlie");
+
+  await input.typeText("l");
+
+  await input.expectOptionLabels(["Alice"]);
+  await expect(input.highlightedOption).toHaveText("Alice");
+});
+
+test("Enter selects the highlighted option", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+  await input.pressKeys("{ArrowDown}{Enter}");
+
+  await input.expectModelState({ text: "@Charlie ", dataValue: "charlie " });
+  await expect(input.modal).toBeHidden();
+});
+
+test("Tab selects the highlighted option", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@bo");
+  await input.pressKeys("{Tab}");
+
+  await input.expectModelState({ text: "@Bob ", dataValue: "bob " });
+  await expect(input.modal).toBeHidden();
+  // Tab must not have moved focus out of the editor.
+  expect(await input.isFocused()).toBe(true);
+});
+
+test("Escape closes the modal without selecting", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@al");
+  await expect(input.modal).toBeVisible();
+
+  await input.pressKeys("{Escape}");
+
+  await expect(input.modal).toBeHidden();
+  await expect(input.chips).toHaveCount(0);
+  await input.expectModelState({ text: "@al" });
+});
+
+test("clicking outside the editor closes the modal", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@al");
+  await expect(input.modal).toBeVisible();
+
+  await input.outside.click();
+
+  await expect(input.modal).toBeHidden();
+  await input.expectModelState({ text: "@al" });
+});
+
+test("Enter inserts a newline when the modal is closed", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("a");
+  await input.pressKeys("{Enter}");
+  await input.typeText("b");
+
+  // Two lines, and the second character landed on the second one. The caret is
+  // asserted as "at the end" rather than at an offset because browsers disagree
+  // on whether a newline occupies a character in textContent — see
+  // expectCaretAtEnd().
+  await input.expectModelState({ displayValue: "a\nb" });
+  await input.expectCaretAtEnd();
+});
+
+test("Shift+Enter inserts a newline like Enter does", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("a");
+  await input.pressKeys("{Shift+Enter}");
+  await input.typeText("b");
+
+  // The component does not distinguish the two: Enter is intercepted before the
+  // modifier is ever consulted.
+  await input.expectModelState({ displayValue: "a\nb" });
+  await input.expectCaretAtEnd();
+});
+
+test("onKeyDown receives ordinary keys but not the modal's navigation keys", async ({
+  harness,
+}) => {
+  const input = harness.case("custom-keydown");
+  const seen = input.page.getByTestId("custom-keydown-keys");
+
+  await input.typeText("x");
+  await expect(seen).toHaveText('["x"]');
+
+  await input.typeText("@");
+  await expect(input.modal).toBeVisible();
+  await input.pressKeys("{ArrowDown}{Escape}");
+
+  // "@" is an ordinary key and reaches the handler; ArrowDown and Escape are
+  // consumed by the modal, as documented in props.mdx.
+  await expect(seen).toHaveText('["x","@"]');
+});
+
+// Bug: props.mdx documents a form-submission pattern where Enter reaches
+// `onKeyDown` once the modal is closed ("When the modal is closed, Enter will
+// trigger the form submission"). It never does — `handleKeyDown` intercepts
+// Enter, inserts a newline and returns before calling `onKeyDown`, so the
+// documented pattern cannot be implemented.
+test.fixme(
+  "onKeyDown receives Enter when the modal is closed",
+  async ({ harness }) => {
+    const input = harness.case("custom-keydown");
+    const seen = input.page.getByTestId("custom-keydown-keys");
+
+    await input.typeText("x");
+    await input.pressKeys("{Enter}");
+
+    await expect(seen).toHaveText('["x","Enter"]');
+  }
+);
+
+// Bug: `handleKeyboardNavigation` returns false when `filteredOptions` is empty,
+// so the Escape branch is never reached and the modal stays open showing "No
+// items found". keyboard-navigation.mdx promises Escape closes the modal, with
+// no exception for an empty list.
+test.fixme(
+  "Escape closes the modal when no options match",
+  async ({ harness }) => {
+    const input = harness.case("default");
+
+    await input.typeText("@zz");
+    await expect(input.noOptions).toBeVisible();
+
+    await input.pressKeys("{Escape}");
+
+    await expect(input.modal).toBeHidden();
+  }
+);
+
+// Bug: Escape closes the modal, but the next keystroke re-runs trigger detection
+// against the text still in the editor, so the modal reopens without the user
+// typing a new trigger. Dismissal does not stick.
+test.fixme(
+  "the modal stays closed after Escape until a new trigger is typed",
+  async ({ harness }) => {
+    const input = harness.case("default");
+
+    await input.typeText("@a");
+    await input.pressKeys("{Escape}");
+    await expect(input.modal).toBeHidden();
+
+    await input.typeText("l");
+
+    await expect(input.modal).toBeHidden();
+  }
+);

--- a/e2e/spec/native-editing.spec.ts
+++ b/e2e/spec/native-editing.spec.ts
@@ -1,0 +1,94 @@
+/**
+ * Native browser editing: undo/redo, select-all, and the caret behaviour the
+ * browser owns rather than the library.
+ *
+ * This file has no counterpart in packages/docs/content/docs — that is itself
+ * worth noting. A contentEditable library lives or dies on how it cooperates
+ * with native editing, and none of it is currently documented, so there is no
+ * stated contract to mirror. These specs record what the browser actually does
+ * today so a change to it is visible.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("native undo reverts typed text", async ({ harness, browserName }) => {
+  test.skip(
+    browserName === "webkit",
+    "webkit does not expose an undo stack for contenteditable through CDP"
+  );
+
+  const input = harness.case("default");
+
+  await input.typeText("hello");
+  await input.expectModelState({ text: "hello" });
+
+  await input.undo();
+
+  // The browser groups a typing burst into one undo step.
+  await expect.poll(() => input.getText()).not.toBe("hello");
+});
+
+test("select-all then delete empties the editor and restores the placeholder", async ({
+  harness,
+}) => {
+  const input = harness.case("placeholder");
+
+  await input.pressKeys("@al{Enter}");
+  await input.typeText("and more");
+  await expect(input.chips).toHaveCount(1);
+
+  await input.selectAll();
+  await input.pressKeys("{Backspace}");
+
+  // The DOM ends up genuinely empty, which is what the placeholder needs. The
+  // reported value does not — see the fixme in onchange.spec.ts.
+  await input.expectModelState({ text: "" });
+  await expect(input.chips).toHaveCount(0);
+  await expect
+    .poll(() => input.editor.evaluate((el) => el.matches(":empty")))
+    .toBe(true);
+});
+
+// Bug: chips are inserted with contentEditable="true", so a caret placed
+// immediately before a chip is a valid editing position *inside* it. Chromium
+// puts the typed character at the chip's start; `processInput` then sees the
+// caret inside a chip and deletes the whole chip — taking the just-typed
+// character with it. Typing in front of a mention silently destroys it: "Alice "
+// plus an "x" becomes " ".
+test.fixme(
+  "typing immediately before a chip inserts text without destroying it",
+  async ({ harness }) => {
+    const input = harness.case("no-trigger");
+
+    await input.pressKeys("@al{Enter}");
+    await input.setCaretBeforeChip(0);
+    await input.typeText("x");
+
+    await input.expectModelState({
+      text: "xAlice ",
+      dataValue: "xalice ",
+      caret: 1,
+    });
+    await expect(input.chips).toHaveCount(1);
+  }
+);
+
+// Bug: `insertMentionIntoDOM` mutates the DOM directly — createElement,
+// replaceChild — which the browser's undo stack knows nothing about. So Ctrl/Cmd+Z
+// after inserting a chip is a no-op: the text the user typed ("@al") is gone and
+// unrecoverable, and the chip cannot be undone either. `insertNewlineAtCaret` has
+// a comment explaining that execCommand is kept precisely because it "leaves the
+// undo stack intact"; chip insertion does not extend the same courtesy.
+test.fixme(
+  "native undo reverts a chip insertion",
+  async ({ harness }) => {
+    const input = harness.case("default");
+
+    await input.pressKeys("@al{Enter}");
+    await expect(input.chips).toHaveCount(1);
+
+    await input.undo();
+
+    await expect(input.chips).toHaveCount(0);
+    await input.expectModelState({ text: "@al" });
+  }
+);

--- a/e2e/spec/onchange.spec.ts
+++ b/e2e/spec/onchange.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * Mirrors docs/content/docs/onchange.mdx — the MentionData payload.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("displayValue carries labels while dataValue carries values", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.pressKeys("hey @al{Enter}");
+
+  await input.expectModelState({
+    displayValue: "hey @Alice ",
+    dataValue: "hey alice ",
+  });
+});
+
+test("each mention reports its label, value and position in displayValue", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.pressKeys("hi @al{Enter}");
+
+  await expect
+    .poll(() => input.getMentions())
+    .toEqual([
+      { label: "Alice", value: "alice", startIndex: 3, endIndex: 9 },
+    ]);
+
+  // The indices are offsets into displayValue, so "@Alice" spans 3..9.
+  const payload = await input.getOnChangePayload();
+  expect(payload!.displayValue.slice(3, 9)).toBe("@Alice");
+});
+
+test("several mentions are reported in document order", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.pressKeys("@al{Enter}");
+  await input.pressKeys("@bo{Enter}");
+
+  await input.expectModelState({
+    displayValue: "@Alice @Bob ",
+    dataValue: "alice bob ",
+  });
+  await expect
+    .poll(() => input.getMentions())
+    .toEqual([
+      { label: "Alice", value: "alice", startIndex: 0, endIndex: 6 },
+      { label: "Bob", value: "bob", startIndex: 7, endIndex: 11 },
+    ]);
+});
+
+test("onChange fires for every edit, including back to empty", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("ab");
+  const afterTyping = await input.getChangeCount();
+  expect(afterTyping).toBeGreaterThanOrEqual(2);
+
+  await input.pressKeys("{Backspace*2}");
+
+  await expect.poll(() => input.getChangeCount()).toBeGreaterThan(afterTyping);
+  await input.expectModelState({ text: "" });
+  expect(await input.getMentions()).toEqual([]);
+});
+
+// Bug: deleting the last character leaves the browser's own filler <br> in the
+// editor. `extractMentionData` counts it as a newline *before* stripping it, so
+// the payload for a now-empty editor reads "\n" while the editor's textContent
+// reads "". A consumer storing that value has "\n" where the user sees nothing,
+// and in controlled mode feeds it straight back in.
+test.fixme("emptying the editor reports an empty value", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("ab");
+  await input.pressKeys("{Backspace*2}");
+
+  await input.expectModelState({ text: "", displayValue: "", dataValue: "" });
+});
+
+test("a mention removed by editing disappears from the payload", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.pressKeys("@al{Enter}");
+  await expect.poll(() => input.getMentions()).toHaveLength(1);
+
+  await input.setCaretAfterChip(0);
+  await input.pressKeys("{Backspace}");
+
+  await expect.poll(() => input.getMentions()).toHaveLength(0);
+  await input.expectModelState({ dataValue: " " });
+});
+
+// Bug: one Enter with nothing typed after it leaves a trailing empty block, and
+// `extractMentionData` counts both the block boundary and the <br> inside it, so
+// a single newline is reported as "\n\n". The editor's own textContent still
+// reads "a" — the model and the DOM disagree about how much content exists.
+test.fixme(
+  "one Enter reports exactly one newline",
+  async ({ harness }) => {
+    const input = harness.case("default");
+
+    await input.typeText("a");
+    await input.pressKeys("{Enter}");
+
+    await input.expectModelState({ displayValue: "a\n", dataValue: "a\n" });
+  }
+);
+
+// Bug: `convertTextToChips` runs on a setTimeout after the input event and never
+// calls onChange, so the conversion is invisible to the consumer. The DOM has a
+// chip; the last payload still says the text is "@Alice " with no mentions.
+test.fixme(
+  "autoConvertMentions reports the converted chip through onChange",
+  async ({ harness }) => {
+    const input = harness.case("auto-convert");
+
+    await input.typeText("@Alice ");
+    await expect(input.chips).toHaveCount(1);
+
+    await expect.poll(() => input.getMentions()).toHaveLength(1);
+    await input.expectModelState({ dataValue: "alice " });
+  }
+);

--- a/e2e/spec/options.spec.ts
+++ b/e2e/spec/options.spec.ts
@@ -1,0 +1,115 @@
+/**
+ * Mirrors docs/content/docs/options.mdx.
+ *
+ * Covers filtering, the duplicate-label case, and function values.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("the option list filters by label as the query grows", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("@a");
+  // Substring match, not prefix: "Charlie" and "Dave" both contain an "a".
+  await input.expectOptionLabels(["Alice", "Charlie", "Dave"]);
+
+  await input.typeText("l");
+  await input.expectOptionLabels(["Alice"]);
+});
+
+test("filtering is case-insensitive", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@BO");
+
+  await input.expectOptionLabels(["Bob"]);
+});
+
+test("a query matching nothing shows the no-options message", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("@zz");
+
+  await expect(input.modal).toBeVisible();
+  await expect(input.options).toHaveCount(0);
+  await expect(input.noOptions).toHaveText("No items found");
+});
+
+test("a space after the trigger closes the modal", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await input.typeText("@al");
+  await expect(input.modal).toBeVisible();
+
+  await input.typeText(" ");
+
+  await expect(input.modal).toBeHidden();
+});
+
+test("two options sharing a label stay distinguishable by value", async ({
+  harness,
+}) => {
+  const input = harness.case("default");
+
+  await input.typeText("@er");
+  await input.expectOptionLabels(["Erin", "Erin"]);
+
+  // Same label, different identity — the ids come from the value.
+  await expect(input.options.nth(0)).toHaveAttribute(
+    "id",
+    "mention-option-erin-primary"
+  );
+  await expect(input.options.nth(1)).toHaveAttribute(
+    "id",
+    "mention-option-erin-backup"
+  );
+
+  // Selecting the second one must yield the second one's value, not the first
+  // label match.
+  await input.pressKeys("{ArrowDown}{Enter}");
+
+  await input.expectModelState({
+    text: "@Erin ",
+    displayValue: "@Erin ",
+    dataValue: "erin-backup ",
+  });
+});
+
+test("an option with a function value runs the function instead of inserting a chip", async ({
+  harness,
+}) => {
+  const input = harness.case("function-value");
+  const calls = input.page.getByTestId("function-value-calls");
+
+  await input.typeText("go @se");
+  await input.expectOptionLabels(["Send"]);
+  await input.pressKeys("{Enter}");
+
+  await expect(calls).toHaveText('["Send"]');
+  await expect(input.chips).toHaveCount(0);
+
+  // The trigger and the query text are removed, and the caret is left where
+  // they were.
+  await input.expectModelState({ text: "go ", caret: 3 });
+  await expect(input.modal).toBeHidden();
+});
+
+// Bug: `reconstructFromDataValue` finds option values by plain substring search
+// and keeps the first match, so "user10" matches the option whose value is
+// "user1" and the leftover "0" is rendered as text. Seeding dataValue "user10"
+// produces an "Ann" chip followed by "0" instead of one "Anna" chip.
+test.fixme(
+  "values where one is a prefix of another reconstruct to the right chip",
+  async ({ harness }) => {
+    const input = harness.case("prefix-values");
+
+    await input.page.getByTestId("prefix-values-seed").click();
+
+    await expect(input.chips).toHaveCount(1);
+    await expect(input.chips.first()).toHaveAttribute("data-value", "user10");
+    await input.expectModelState({ text: "@Anna" });
+  }
+);

--- a/e2e/spec/props.spec.ts
+++ b/e2e/spec/props.spec.ts
@@ -1,0 +1,146 @@
+/**
+ * Mirrors docs/content/docs/props.mdx — `trigger`, `keepTriggerOnSelect`,
+ * `autoConvertMentions`, `displayValue`/`dataValue`, and the placeholder.
+ */
+import { test, expect, OPTION_LABELS } from "../fixtures/harness";
+
+test("a custom single-character trigger opens the modal", async ({
+  harness,
+}) => {
+  const input = harness.case("custom-trigger");
+
+  await input.typeText("#");
+  await input.expectOptionLabels(OPTION_LABELS);
+
+  await input.pressKeys("bo{Enter}");
+
+  await input.expectModelState({ text: "#Bob ", dataValue: "bob " });
+});
+
+test("the default trigger does nothing when a custom one is set", async ({
+  harness,
+}) => {
+  const input = harness.case("custom-trigger");
+
+  await input.typeText("@al");
+
+  await expect(input.modal).toBeHidden();
+  await input.expectModelState({ text: "@al" });
+});
+
+test("keepTriggerOnSelect={false} drops the trigger from the chip text", async ({
+  harness,
+}) => {
+  const input = harness.case("no-trigger");
+
+  await input.pressKeys("@bo{Enter}");
+
+  await expect(input.chips.first()).toHaveText("Bob");
+  await input.expectModelState({
+    text: "Bob ",
+    displayValue: "Bob ",
+    dataValue: "bob ",
+  });
+});
+
+test("autoConvertMentions turns typed text into a chip on space", async ({
+  harness,
+}) => {
+  const input = harness.case("auto-convert");
+
+  await input.typeText("@Alice ");
+
+  // The conversion itself works; what it writes into data-value does not — see
+  // the fixme in chips.spec.ts.
+  await expect(input.chips).toHaveCount(1);
+  await expect(input.chips.first()).toHaveText("Alice");
+});
+
+test("the custom placeholder shows while the editor is empty", async ({
+  harness,
+}) => {
+  const input = harness.case("placeholder");
+
+  await expect(input.editor).toHaveAttribute(
+    "data-placeholder",
+    "Say something..."
+  );
+  // The placeholder is CSS, rendered from data-placeholder via :empty::before,
+  // so "is it showing" is really "is the editor empty".
+  expect(await input.editor.evaluate((el) => el.matches(":empty"))).toBe(true);
+
+  await input.typeText("x");
+
+  expect(await input.editor.evaluate((el) => el.matches(":empty"))).toBe(false);
+});
+
+test("the placeholder returns after a controlled dataValue is cleared", async ({
+  harness,
+}) => {
+  const input = harness.case("controlled");
+
+  await input.pressKeys("@al{Enter}");
+  await input.typeText("hello");
+  await expect(input.chips).toHaveCount(1);
+
+  await input.page.getByTestId("controlled-clear").click();
+
+  // The chip and every stray node must go, or :empty never matches and the
+  // placeholder stays hidden — the failure afdf240 was chasing.
+  await expect(input.chips).toHaveCount(0);
+  await input.expectModelState({ text: "" });
+  await expect
+    .poll(() => input.editor.evaluate((el) => el.matches(":empty")))
+    .toBe(true);
+});
+
+test("a controlled dataValue reconstructs chips from values", async ({
+  harness,
+}) => {
+  const input = harness.case("controlled");
+
+  await input.page.getByTestId("controlled-seed").click();
+
+  await input.expectModelState({ text: "hi @Erin" });
+  await expect(input.chips).toHaveCount(1);
+  await expect(input.chips.first()).toHaveAttribute(
+    "data-value",
+    "erin-primary"
+  );
+  await expect(input.chips.first()).toHaveText("@Erin");
+});
+
+// Bug: `detectMentionTrigger` finds the trigger with `lastIndexOf` but then
+// slices the query with `lastTriggerIndex + 1`, hard-coding a one-character
+// trigger. With trigger "::" the query keeps the second colon, so nothing ever
+// matches and the modal only ever shows "No items found". props.mdx explicitly
+// documents multi-character triggers ("or even a multi-character string (e.g.
+// `::`)").
+test.fixme("a multi-character trigger matches options", async ({ harness }) => {
+  const input = harness.case("multi-char-trigger");
+
+  await input.typeText("::al");
+
+  await input.expectOptionLabels(["Alice"]);
+  await input.pressKeys("{Enter}");
+  await input.expectModelState({ text: "::Alice ", dataValue: "alice " });
+});
+
+// Bug: in controlled `displayValue` mode the reconciliation effect compares the
+// editor's raw textContent against the prop. Once the content holds a newline the
+// two can never agree — the DOM says "Zabcd", the model says "Z\nabcd" — so the
+// effect rewrites textContent on every change. That destroys the text nodes and
+// the caret collapses to offset 0, meaning the next character typed lands at the
+// *start* of the input.
+test.fixme(
+  "controlled displayValue keeps the caret across a newline",
+  async ({ harness }) => {
+    const input = harness.case("display-value");
+
+    await input.typeText("ab");
+    await input.pressKeys("{Enter}");
+    await input.typeText("c");
+
+    await input.expectModelState({ displayValue: "ab\nc", caret: 3 });
+  }
+);

--- a/e2e/spec/styling.spec.ts
+++ b/e2e/spec/styling.spec.ts
@@ -1,0 +1,98 @@
+/**
+ * Mirrors docs/content/docs/styling.mdx — the slotsProps className contract.
+ *
+ * Worth having at this layer rather than in happy-dom: these assertions read
+ * *computed* style, so they catch a class that is applied but has no effect
+ * because the rule it needed was replaced rather than extended.
+ */
+import { test, expect } from "../fixtures/harness";
+
+test("the default classes are applied out of the box", async ({ harness }) => {
+  const input = harness.case("default");
+
+  await expect(
+    input.section.locator(".mention-input-container")
+  ).toHaveCount(1);
+  await expect(input.editor).toHaveClass("content-editable-input");
+
+  await input.typeText("@al");
+
+  await expect(input.modal).toHaveClass("mention-modal");
+  await expect(input.options.first()).toHaveClass(
+    "mention-option mention-option-highlighted"
+  );
+
+  await input.pressKeys("{Enter}");
+  await expect(input.chips.first()).toHaveClass("mention-chip");
+});
+
+test("contentEditable, modal and chip classNames extend the defaults", async ({
+  harness,
+}) => {
+  const input = harness.case("styled");
+
+  await expect(input.editor).toHaveClass("content-editable-input harness-input");
+
+  await input.typeText("@al");
+  await expect(input.modal).toHaveClass("mention-modal harness-modal");
+
+  await input.pressKeys("{Enter}");
+  await expect(input.chips.first()).toHaveClass("mention-chip harness-chip");
+
+  // And the custom rule actually wins.
+  await expect(input.chips.first()).toHaveCSS(
+    "background-color",
+    "rgb(0, 128, 0)"
+  );
+});
+
+test("highlightedClassName replaces the default highlight class", async ({
+  harness,
+}) => {
+  const input = harness.case("styled");
+
+  await input.typeText("@a");
+
+  await expect(input.options.first()).toHaveClass(
+    "harness-option harness-option-highlighted"
+  );
+  await expect(input.options.first()).toHaveCSS(
+    "background-color",
+    "rgb(255, 0, 0)"
+  );
+  await expect(input.options.nth(1)).toHaveClass("harness-option");
+});
+
+test("the no-options element takes its custom className", async ({
+  harness,
+}) => {
+  const input = harness.case("styled");
+
+  await input.typeText("@zz");
+
+  await expect(input.noOptions).toHaveClass("harness-no-options");
+  await expect(input.noOptions).toHaveText("No items found");
+});
+
+// Bug: `container` and `option` classNames *replace* the built-in class rather
+// than extending it, while `contentEditable`, `modal` and `chipClassName` extend
+// theirs. For the container that is a functional break, not just a cosmetic one:
+// the default class supplies `position: relative`, which is the containing block
+// the absolutely-positioned modal is placed against, so styling the container
+// detaches the dropdown from the input. styling.mdx documents all the slots the
+// same way and warns about neither.
+test.fixme(
+  "slot classNames extend the defaults consistently",
+  async ({ harness }) => {
+    const input = harness.case("styled");
+
+    await expect(
+      input.section.locator(".mention-input-container")
+    ).toHaveClass("mention-input-container harness-container");
+
+    await input.typeText("@a");
+    await expect(input.options.first()).toHaveClass(
+      /mention-option(?=.*harness-option)/
+    );
+  }
+);

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "lib": ["es2023", "dom"],
+    "module": "preserve",
+    "moduleResolution": "bundler",
+    "moduleDetection": "force",
+    "types": ["node"],
+    "strict": true,
+    "noEmit": true,
+    "noUnusedLocals": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "skipLibCheck": true
+  },
+  "include": ["**/*.ts", "../playwright.config.ts"]
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:report": "playwright show-report",
     "typecheck": "turbo run typecheck",
+    "typecheck:e2e": "tsc --noEmit -p e2e/tsconfig.json",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only",
     "release": "changeset publish"
@@ -29,7 +30,9 @@
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.1",
     "@playwright/test": "^1.62.1",
-    "turbo": "^2.5.0"
+    "@types/node": "^26.1.2",
+    "turbo": "^2.5.0",
+    "typescript": "~5.8.3"
   },
   "packageManager": "pnpm@10.10.0",
   "pnpm": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,10 @@
     "dev": "turbo run dev",
     "build": "turbo run build",
     "test": "turbo run test",
+    "test:e2e": "playwright test",
+    "test:e2e:chromium": "playwright test --project=chromium",
+    "test:e2e:ui": "playwright test --ui",
+    "test:e2e:report": "playwright show-report",
     "typecheck": "turbo run typecheck",
     "changeset": "changeset",
     "version-packages": "changeset version && pnpm install --lockfile-only",
@@ -24,6 +28,7 @@
   "devDependencies": {
     "@changesets/changelog-github": "^0.7.0",
     "@changesets/cli": "^2.31.1",
+    "@playwright/test": "^1.62.1",
     "turbo": "^2.5.0"
   },
   "packageManager": "pnpm@10.10.0",

--- a/packages/mentis/package.json
+++ b/packages/mentis/package.json
@@ -43,6 +43,7 @@
     "build": "tsdown",
     "dev": "tsdown --watch",
     "playground": "vite --config playground/vite.config.ts",
+    "playground:e2e": "vite --config playground/vite.config.ts --port 5273 --strictPort",
     "test": "vitest",
     "typecheck": "tsc --noEmit",
     "prepack": "./scripts/prepack.sh",

--- a/packages/mentis/playground/e2e.html
+++ b/packages/mentis/playground/e2e.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>mentis e2e harness</title>
+  </head>
+  <body>
+    <!--
+      Deterministic harness for the Playwright suite in /e2e.
+      Do not add cases here casually: every instance below is asserted against.
+      See e2e/README.md.
+    -->
+    <div id="app"></div>
+    <script type="module" src="/src/e2e.tsx"></script>
+  </body>
+</html>

--- a/packages/mentis/playground/src/E2EHarness.tsx
+++ b/packages/mentis/playground/src/E2EHarness.tsx
@@ -209,6 +209,20 @@ export function E2EHarness() {
     <main className="harness">
       <h1>mentis e2e harness</h1>
 
+      {/*
+        Copy source for the real-clipboard tests. A spec fills this in, selects
+        it and presses the copy shortcut, which puts content on the actual OS
+        clipboard with both text/plain and text/html flavours — the only way to
+        exercise a genuine paste in browsers that will not let Playwright grant
+        clipboard permissions or fake a ClipboardEvent.
+      */}
+      <div
+        className="harness-clipboard"
+        contentEditable
+        suppressContentEditableWarning
+        data-testid="clipboard-source"
+      />
+
       <Case id="default" title="defaults">
         {(record) => <MentionInput options={OPTIONS} onChange={record} />}
       </Case>

--- a/packages/mentis/playground/src/E2EHarness.tsx
+++ b/packages/mentis/playground/src/E2EHarness.tsx
@@ -1,0 +1,313 @@
+import React, { useCallback, useState } from "react";
+import {
+  MentionInput,
+  type MentionData,
+  type MentionOption,
+} from "../../src/index.js";
+
+/**
+ * Deterministic harness page for the Playwright suite in /e2e.
+ *
+ * Rules for this file:
+ *
+ * 1. It is a test fixture, not a demo. `App.tsx` is the scratchpad; this file
+ *    changes only when a spec needs it to, and changing it means updating the
+ *    specs that read it.
+ * 2. Every case is wrapped in `<section data-testid="mention-<id>">`. Specs
+ *    scope all their locators to that section, so cases never interfere.
+ * 3. Every case renders `<pre data-testid="<id>-onchange">` holding
+ *    `{"count":n,"data":MentionData|null}`. `count` lets a spec wait for the
+ *    *next* onChange rather than racing the current one.
+ * 4. Option lists are module-level constants so they are referentially stable —
+ *    `options` is a dependency of the reconciliation effect inside
+ *    `useMentionInput`, and an inline array would re-run it on every render.
+ */
+
+/**
+ * The shared option list. Alphabetically stable, and deliberately containing a
+ * duplicate label ("Erin") with two distinct values — a case the library
+ * currently mishandles in places, so it needs pinning.
+ *
+ * Query cheat-sheet (labels are matched case-insensitively, substring):
+ *   ""    -> Alice, Bob, Charlie, Dave, Erin, Erin   (6)
+ *   "a"   -> Alice, Charlie, Dave                    (3)
+ *   "al"  -> Alice                                   (1)
+ *   "er"  -> Erin, Erin                              (2, the duplicate pair)
+ *   "zz"  -> none
+ */
+export const OPTIONS: MentionOption[] = [
+  { label: "Alice", value: "alice" },
+  { label: "Bob", value: "bob" },
+  { label: "Charlie", value: "charlie" },
+  { label: "Dave", value: "dave" },
+  { label: "Erin", value: "erin-primary" },
+  { label: "Erin", value: "erin-backup" },
+];
+
+/**
+ * Values where one is a prefix of the other, with no separator between the
+ * shared part and the rest. `reconstructFromDataValue` scans for option values
+ * by substring, so these collide.
+ */
+const PREFIX_OPTIONS: MentionOption[] = [
+  { label: "Ann", value: "user1" },
+  { label: "Anna", value: "user10" },
+];
+
+type ChangeLog = { count: number; data: MentionData | null };
+
+const EMPTY_LOG: ChangeLog = { count: 0, data: null };
+
+/**
+ * Section chrome shared by every case: a stable testid, an out-of-the-way click
+ * target for click-outside tests, and the onChange log.
+ *
+ * The outside target sits *above* the input on purpose — the modal renders
+ * absolutely positioned below the input, so a target placed after it would be
+ * covered by the modal and a "click outside" would land on an option instead.
+ */
+function Case({
+  id,
+  title,
+  children,
+}: {
+  id: string;
+  title: string;
+  children: (record: (data: MentionData) => void) => React.ReactNode;
+}) {
+  const [log, setLog] = useState<ChangeLog>(EMPTY_LOG);
+
+  const record = useCallback((data: MentionData) => {
+    setLog((previous) => ({ count: previous.count + 1, data }));
+  }, []);
+
+  return (
+    <section className="harness-case" data-testid={`mention-${id}`}>
+      <h2 className="harness-title">
+        {title} <code>{id}</code>
+      </h2>
+      <div className="harness-outside" data-testid={`${id}-outside`}>
+        outside
+      </div>
+      {children(record)}
+      <pre className="harness-log" data-testid={`${id}-onchange`}>
+        {JSON.stringify(log)}
+      </pre>
+    </section>
+  );
+}
+
+/** `dataValue` as a controlled prop, plus the round-trip and clear controls. */
+function ControlledCase({
+  id,
+  record,
+  options = OPTIONS,
+  seedDataValue = "",
+}: {
+  id: string;
+  record: (data: MentionData) => void;
+  options?: MentionOption[];
+  seedDataValue?: string;
+}) {
+  const [dataValue, setDataValue] = useState("");
+
+  return (
+    <>
+      <MentionInput
+        options={options}
+        dataValue={dataValue}
+        onChange={(data) => {
+          setDataValue(data.dataValue);
+          record(data);
+        }}
+      />
+      <div className="harness-controls">
+        <button data-testid={`${id}-clear`} onClick={() => setDataValue("")}>
+          Clear
+        </button>
+        <button
+          data-testid={`${id}-seed`}
+          onClick={() => setDataValue(seedDataValue)}
+        >
+          Seed
+        </button>
+      </div>
+      <pre className="harness-datavalue" data-testid={`${id}-datavalue`}>
+        {dataValue}
+      </pre>
+    </>
+  );
+}
+
+/** `displayValue` as a controlled prop. */
+function DisplayValueCase({ record }: { record: (data: MentionData) => void }) {
+  const [displayValue, setDisplayValue] = useState("");
+
+  return (
+    <>
+      <MentionInput
+        options={OPTIONS}
+        displayValue={displayValue}
+        onChange={(data) => {
+          setDisplayValue(data.displayValue);
+          record(data);
+        }}
+      />
+      <div className="harness-controls">
+        <button
+          data-testid="display-value-clear"
+          onClick={() => setDisplayValue("")}
+        >
+          Clear
+        </button>
+      </div>
+    </>
+  );
+}
+
+/**
+ * An option whose `value` is a function. The call is recorded in the DOM rather
+ * than via `alert()`, so a spec can assert it without driving a dialog.
+ */
+function FunctionValueCase({ record }: { record: (data: MentionData) => void }) {
+  const [calls, setCalls] = useState<string[]>([]);
+
+  const [options] = useState<MentionOption[]>(() => [
+    ...OPTIONS,
+    {
+      label: "Send",
+      value: () => setCalls((previous) => [...previous, "Send"]),
+    },
+  ]);
+
+  return (
+    <>
+      <MentionInput options={options} onChange={record} />
+      <pre data-testid="function-value-calls">{JSON.stringify(calls)}</pre>
+    </>
+  );
+}
+
+/** Records every key the `onKeyDown` prop is actually called for. */
+function KeyDownCase({ record }: { record: (data: MentionData) => void }) {
+  const [keys, setKeys] = useState<string[]>([]);
+
+  return (
+    <>
+      <MentionInput
+        options={OPTIONS}
+        onChange={record}
+        onKeyDown={(event) => setKeys((previous) => [...previous, event.key])}
+      />
+      <pre data-testid="custom-keydown-keys">{JSON.stringify(keys)}</pre>
+    </>
+  );
+}
+
+export function E2EHarness() {
+  return (
+    <main className="harness">
+      <h1>mentis e2e harness</h1>
+
+      <Case id="default" title="defaults">
+        {(record) => <MentionInput options={OPTIONS} onChange={record} />}
+      </Case>
+
+      <Case id="controlled" title="controlled dataValue">
+        {(record) => (
+          <ControlledCase
+            id="controlled"
+            record={record}
+            seedDataValue="hi erin-primary"
+          />
+        )}
+      </Case>
+
+      <Case id="display-value" title="controlled displayValue">
+        {(record) => <DisplayValueCase record={record} />}
+      </Case>
+
+      <Case id="no-trigger" title="keepTriggerOnSelect={false}">
+        {(record) => (
+          <MentionInput
+            options={OPTIONS}
+            keepTriggerOnSelect={false}
+            onChange={record}
+          />
+        )}
+      </Case>
+
+      <Case id="auto-convert" title="autoConvertMentions">
+        {(record) => (
+          <MentionInput
+            options={OPTIONS}
+            autoConvertMentions
+            keepTriggerOnSelect={false}
+            onChange={record}
+          />
+        )}
+      </Case>
+
+      <Case id="custom-trigger" title='trigger="#"'>
+        {(record) => (
+          <MentionInput options={OPTIONS} trigger="#" onChange={record} />
+        )}
+      </Case>
+
+      <Case id="multi-char-trigger" title='trigger="::"'>
+        {(record) => (
+          <MentionInput options={OPTIONS} trigger="::" onChange={record} />
+        )}
+      </Case>
+
+      <Case id="function-value" title="option with a function value">
+        {(record) => <FunctionValueCase record={record} />}
+      </Case>
+
+      <Case id="custom-keydown" title="onKeyDown prop">
+        {(record) => <KeyDownCase record={record} />}
+      </Case>
+
+      <Case id="prefix-values" title="values where one is a prefix of another">
+        {(record) => (
+          <ControlledCase
+            id="prefix-values"
+            record={record}
+            options={PREFIX_OPTIONS}
+            seedDataValue="user10"
+          />
+        )}
+      </Case>
+
+      <Case id="placeholder" title="custom placeholder">
+        {(record) => (
+          <MentionInput
+            options={OPTIONS}
+            onChange={record}
+            slotsProps={{
+              contentEditable: { "data-placeholder": "Say something..." },
+            }}
+          />
+        )}
+      </Case>
+
+      <Case id="styled" title="every slot restyled">
+        {(record) => (
+          <MentionInput
+            options={OPTIONS}
+            onChange={record}
+            slotsProps={{
+              container: { className: "harness-container" },
+              contentEditable: { className: "harness-input" },
+              modal: { className: "harness-modal" },
+              option: { className: "harness-option" },
+              noOptions: { className: "harness-no-options" },
+              highlightedClassName: "harness-option-highlighted",
+              chipClassName: "harness-chip",
+            }}
+          />
+        )}
+      </Case>
+    </main>
+  );
+}

--- a/packages/mentis/playground/src/e2e.css
+++ b/packages/mentis/playground/src/e2e.css
@@ -1,0 +1,121 @@
+/*
+ * Styling for the e2e harness page. Kept separate from `style.css` (the demo
+ * playground's) so changes to the demo cannot move the harness underneath the
+ * Playwright suite.
+ *
+ * The classes prefixed `harness-` in the "styled" case are asserted against by
+ * e2e/spec/styling.spec.ts — their declared values are part of the contract.
+ */
+
+body {
+  margin: 0;
+  padding: 24px;
+  font-family: system-ui, sans-serif;
+  background: #fff;
+  color: #111;
+}
+
+.harness > h1 {
+  font-size: 18px;
+}
+
+/*
+ * The modal is absolutely positioned below its input and is out of flow, so each
+ * case needs enough trailing space that an open modal cannot cover the *next*
+ * case's input. Overlap would make clicks land on the wrong element.
+ */
+.harness-case {
+  width: 320px;
+  margin: 0 0 280px;
+}
+
+.harness-title {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0 0 8px;
+}
+
+.harness-title code {
+  font-weight: 400;
+  color: #666;
+}
+
+/*
+ * Click target for click-outside tests. Sits above the input because the modal
+ * opens downwards — a target below the input would be covered by the modal, and
+ * the "outside" click would select an option instead.
+ */
+.harness-outside {
+  padding: 8px;
+  margin-bottom: 8px;
+  border: 1px dashed #bbb;
+  color: #666;
+  font-size: 12px;
+}
+
+.harness-controls {
+  margin-top: 8px;
+  display: flex;
+  gap: 8px;
+}
+
+.harness-log,
+.harness-datavalue {
+  margin: 8px 0 0;
+  padding: 4px;
+  max-width: 320px;
+  overflow-x: auto;
+  background: #f6f6f6;
+  font-size: 11px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* --- the "styled" case: every slot overridden ---------------------------- */
+
+/*
+ * `position: relative` is restated here because `slotsProps.container.className`
+ * *replaces* `mention-input-container` rather than merging with it (the spread
+ * lands after the className), which would otherwise drop the containing block
+ * the modal positions against. Pinned by e2e/spec/styling.spec.ts.
+ */
+.harness-container {
+  position: relative;
+  width: 100%;
+}
+
+.harness-input {
+  padding: 10px;
+  border: 2px solid rgb(0, 0, 255);
+  border-radius: 0;
+  outline: none;
+  white-space: pre-wrap;
+}
+
+.harness-modal {
+  position: absolute;
+  width: 100%;
+  background: rgb(255, 255, 240);
+  border: 1px solid #333;
+}
+
+.harness-option {
+  padding: 6px;
+  cursor: pointer;
+}
+
+.harness-option-highlighted {
+  background: rgb(255, 0, 0);
+}
+
+.harness-no-options {
+  padding: 6px;
+  color: rgb(128, 128, 128);
+}
+
+.harness-chip {
+  background: rgb(0, 128, 0);
+  color: rgb(255, 255, 255);
+  border-radius: 999px;
+  padding: 0 6px;
+}

--- a/packages/mentis/playground/src/e2e.css
+++ b/packages/mentis/playground/src/e2e.css
@@ -53,6 +53,18 @@ body {
   font-size: 12px;
 }
 
+/* Copy source for the real-clipboard tests. Visible and focusable — a hidden or
+ * zero-size element cannot be selected and copied from. */
+.harness-clipboard {
+  width: 320px;
+  min-height: 20px;
+  margin-bottom: 24px;
+  padding: 4px;
+  border: 1px dotted #999;
+  font-size: 12px;
+  white-space: pre-wrap;
+}
+
 .harness-controls {
   margin-top: 8px;
   display: flex;

--- a/packages/mentis/playground/src/e2e.tsx
+++ b/packages/mentis/playground/src/e2e.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+import { createRoot } from "react-dom/client";
+import { E2EHarness } from "./E2EHarness.tsx";
+import "./e2e.css";
+
+// Deliberately not wrapped in StrictMode: double-invoked effects would make the
+// contentEditable reconciliation non-deterministic, and the e2e suite exists to
+// pin down deterministic behaviour.
+createRoot(document.querySelector("#app")!).render(<E2EHarness />);

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,77 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * Playwright config for the e2e layer. See e2e/README.md for what this layer
+ * owns and what belongs in vitest instead.
+ *
+ * `pnpm test` (vitest, in packages/mentis) and `pnpm test:e2e` (this) are kept
+ * deliberately separate — they are different layers with different guarantees,
+ * and conflating them is how the fake DOM ended up dictating production code.
+ */
+
+/**
+ * A port of its own, not vite's default 5173: the demo playground commonly runs
+ * there during development, and the suite must never accidentally attach to it
+ * and assert against the demo page.
+ */
+const PORT = 5273;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  // Both spec/ and regressions/ live under testDir; nothing else there is a test.
+  testMatch: /.*\.spec\.ts/,
+
+  // The suite drives a contentEditable through real key events. Nothing here is
+  // allowed to depend on test order or on a shared server-side state.
+  fullyParallel: true,
+
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 2 : undefined,
+
+  reporter: process.env.CI
+    ? [["html", { open: "never" }], ["github"], ["list"]]
+    : [["html", { open: "never" }], ["list"]],
+
+  use: {
+    baseURL: BASE_URL,
+    trace: "on-first-retry",
+    screenshot: "only-on-failure",
+    video: "off",
+  },
+
+  expect: {
+    timeout: 5_000,
+  },
+
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+    {
+      name: "webkit",
+      use: { ...devices["Desktop Safari"] },
+    },
+    {
+      // Mobile keyboards and touch carets are where contentEditable libraries
+      // die, so the mobile project is not optional.
+      name: "mobile-chrome",
+      use: { ...devices["Pixel 7"] },
+    },
+  ],
+
+  webServer: {
+    command: "pnpm --filter mentis playground:e2e",
+    url: `${BASE_URL}/e2e.html`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    stdout: "ignore",
+    stderr: "pipe",
+  },
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -21,6 +21,9 @@ export default defineConfig({
   testDir: "./e2e",
   // Both spec/ and regressions/ live under testDir; nothing else there is a test.
   testMatch: /.*\.spec\.ts/,
+  // `_template.spec.ts` exists to be copied, not run. It is still typechecked by
+  // `pnpm typecheck:e2e`, so it cannot rot unnoticed.
+  testIgnore: "**/_*.spec.ts",
 
   // The suite drives a contentEditable through real key events. Nothing here is
   // allowed to depend on test order or on a shared server-side state.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,13 +16,19 @@ importers:
         version: 0.7.0
       '@changesets/cli':
         specifier: ^2.31.1
-        version: 2.31.1(@types/node@24.0.15)
+        version: 2.31.1(@types/node@26.1.2)
       '@playwright/test':
         specifier: ^1.62.1
         version: 1.62.1
+      '@types/node':
+        specifier: ^26.1.2
+        version: 26.1.2
       turbo:
         specifier: ^2.5.0
         version: 2.5.5
+      typescript:
+        specifier: ~5.8.3
+        version: 5.8.3
 
   packages/docs:
     dependencies:
@@ -208,13 +214,13 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 4.7.0(vite@7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
         specifier: ^7.0.4
-        version: 7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+        version: 7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
   packages/examples/styling:
     dependencies:
@@ -236,19 +242,19 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 4.7.0(vite@7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
         specifier: ^7.0.4
-        version: 7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+        version: 7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
   packages/examples/tailwind:
     dependencies:
       '@tailwindcss/vite':
         specifier: ^4.1.11
-        version: 4.1.11(vite@7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 4.1.11(vite@7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       mentis:
         specifier: 0.1.1-alpha.4
         version: 0.1.1-alpha.4(react@19.1.0)
@@ -270,13 +276,13 @@ importers:
         version: 19.1.6(@types/react@19.1.8)
       '@vitejs/plugin-react':
         specifier: ^4.6.0
-        version: 4.7.0(vite@7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
+        version: 4.7.0(vite@7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
       vite:
         specifier: ^7.0.4
-        version: 7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+        version: 7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
   packages/mentis:
     dependencies:
@@ -1791,6 +1797,9 @@ packages:
 
   '@types/node@24.0.7':
     resolution: {integrity: sha512-YIEUUr4yf8q8oQoXPpSlnvKNVKDQlPMWrmOcgzoduo7kvA2UF0/BwJ/eMKFTiTtkNL17I0M6Xe2tvwFU7be6iw==}
+
+  '@types/node@26.1.2':
+    resolution: {integrity: sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==}
 
   '@types/react-dom@19.1.6':
     resolution: {integrity: sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==}
@@ -4303,6 +4312,9 @@ packages:
   undici-types@7.8.0:
     resolution: {integrity: sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==}
 
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
+
   unified@11.0.5:
     resolution: {integrity: sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==}
 
@@ -4710,7 +4722,7 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@changesets/cli@2.31.1(@types/node@24.0.15)':
+  '@changesets/cli@2.31.1(@types/node@26.1.2)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10
@@ -4726,7 +4738,7 @@ snapshots:
       '@changesets/should-skip-package': 0.1.2
       '@changesets/types': 6.1.0
       '@changesets/write': 0.4.0
-      '@inquirer/external-editor': 1.0.3(@types/node@24.0.15)
+      '@inquirer/external-editor': 1.0.3(@types/node@26.1.2)
       '@manypkg/get-packages': 1.1.3
       ansi-colors: 4.1.3
       enquirer: 2.4.1
@@ -5120,12 +5132,12 @@ snapshots:
   '@img/sharp-win32-x64@0.34.3':
     optional: true
 
-  '@inquirer/external-editor@1.0.3(@types/node@24.0.15)':
+  '@inquirer/external-editor@1.0.3(@types/node@26.1.2)':
     dependencies:
       chardet: 2.2.0
       iconv-lite: 0.7.3
     optionalDependencies:
-      '@types/node': 24.0.15
+      '@types/node': 26.1.2
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -5858,12 +5870,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.11
 
-  '@tailwindcss/vite@4.1.11(vite@7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+  '@tailwindcss/vite@4.1.11(vite@7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
     dependencies:
       '@tailwindcss/node': 4.1.11
       '@tailwindcss/oxide': 4.1.11
       tailwindcss: 4.1.11
-      vite: 7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+      vite: 7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
 
   '@testing-library/dom@10.4.0':
     dependencies:
@@ -5975,6 +5987,10 @@ snapshots:
   '@types/node@24.0.7':
     dependencies:
       undici-types: 7.8.0
+
+  '@types/node@26.1.2':
+    dependencies:
+      undici-types: 8.3.0
 
   '@types/react-dom@19.1.6(@types/react@19.1.8)':
     dependencies:
@@ -6205,6 +6221,18 @@ snapshots:
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
       vite: 7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
+    transitivePeerDependencies:
+      - supports-color
+
+  '@vitejs/plugin-react@4.7.0(vite@7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))':
+    dependencies:
+      '@babel/core': 7.28.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.28.0)
+      '@rolldown/pluginutils': 1.0.0-beta.27
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.17.0
+      vite: 7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -9315,6 +9343,8 @@ snapshots:
 
   undici-types@7.8.0: {}
 
+  undici-types@8.3.0: {}
+
   unified@11.0.5:
     dependencies:
       '@types/unist': 3.0.3
@@ -9450,6 +9480,21 @@ snapshots:
       tinyglobby: 0.2.14
     optionalDependencies:
       '@types/node': 24.0.15
+      fsevents: 2.3.3
+      jiti: 2.4.2
+      lightningcss: 1.30.1
+      yaml: 2.8.0
+
+  vite@7.0.5(@types/node@26.1.2)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0):
+    dependencies:
+      esbuild: 0.25.7
+      fdir: 6.4.6(picomatch@4.0.3)
+      picomatch: 4.0.3
+      postcss: 8.5.6
+      rollup: 4.45.1
+      tinyglobby: 0.2.14
+    optionalDependencies:
+      '@types/node': 26.1.2
       fsevents: 2.3.3
       jiti: 2.4.2
       lightningcss: 1.30.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.1
         version: 2.31.1(@types/node@24.0.15)
+      '@playwright/test':
+        specifier: ^1.62.1
+        version: 1.62.1
       turbo:
         specifier: ^2.5.0
         version: 2.5.5
@@ -25,13 +28,13 @@ importers:
     dependencies:
       fumadocs-core:
         specifier: 15.6.3
-        version: 15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       fumadocs-mdx:
         specifier: 11.6.10
-        version: 11.6.10(acorn@8.15.0)(fumadocs-core@15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
+        version: 11.6.10(acorn@8.15.0)(fumadocs-core@15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))
       fumadocs-ui:
         specifier: 15.6.3
-        version: 15.6.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)
+        version: 15.6.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11)
       lucide-react:
         specifier: ^0.525.0
         version: 0.525.0(react@19.1.0)
@@ -40,7 +43,7 @@ importers:
         version: 0.2.0-alpha.2(react@19.1.0)
       next:
         specifier: 15.5.22
-        version: 15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
@@ -94,7 +97,7 @@ importers:
         version: 0.2.0-alpha.2(react@19.1.0)
       next:
         specifier: 15.5.22
-        version: 15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -146,7 +149,7 @@ importers:
         version: 0.2.0-alpha.4(react@19.1.0)
       next:
         specifier: 15.5.22
-        version: 15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -1020,6 +1023,11 @@ packages:
 
   '@oxc-project/types@0.77.2':
     resolution: {integrity: sha512-+ZFWJF8ZBTOIO5PiNohNIw7JBzJCybScfrhLh65tcHCAtqaQkVDonjRD1HmMV/RF3rtt3r88hzSyTqvXs4j7vw==}
+
+  '@playwright/test@1.62.1':
+    resolution: {integrity: sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   '@quansync/fs@0.1.3':
     resolution: {integrity: sha512-G0OnZbMWEs5LhDyqy2UL17vGhSVHkQIfVojMtEWVenvj0V5S84VBgy86kJIuNsGDp2p7sTKlpSIpBUWdC35OKg==}
@@ -2707,6 +2715,11 @@ packages:
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -3684,6 +3697,16 @@ packages:
   pify@4.0.1:
     resolution: {integrity: sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==}
     engines: {node: '>=6'}
+
+  playwright-core@1.62.1:
+    resolution: {integrity: sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  playwright@1.62.1:
+    resolution: {integrity: sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==}
+    engines: {node: '>=20'}
+    hasBin: true
 
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
@@ -5240,6 +5263,10 @@ snapshots:
   '@oxc-project/runtime@0.77.2': {}
 
   '@oxc-project/types@0.77.2': {}
+
+  '@playwright/test@1.62.1':
+    dependencies:
+      playwright: 1.62.1
 
   '@quansync/fs@0.1.3':
     dependencies:
@@ -7268,10 +7295,13 @@ snapshots:
 
   fs.realpath@1.0.0: {}
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
-  fumadocs-core@15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  fumadocs-core@15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.1
       '@orama/orama': 3.1.11
@@ -7292,20 +7322,20 @@ snapshots:
       unist-util-visit: 5.0.0
     optionalDependencies:
       '@types/react': 19.1.8
-      next: 15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
 
-  fumadocs-mdx@11.6.10(acorn@8.15.0)(fumadocs-core@15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
+  fumadocs-mdx@11.6.10(acorn@8.15.0)(fumadocs-core@15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)):
     dependencies:
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       '@standard-schema/spec': 1.0.0
       chokidar: 4.0.3
       esbuild: 0.25.7
       estree-util-value-to-estree: 3.4.0
-      fumadocs-core: 15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      fumadocs-core: 15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       js-yaml: 4.1.0
       lru-cache: 11.1.0
       picocolors: 1.1.1
@@ -7314,12 +7344,12 @@ snapshots:
       unist-util-visit: 5.0.0
       zod: 3.25.76
     optionalDependencies:
-      next: 15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - acorn
       - supports-color
 
-  fumadocs-ui@15.6.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11):
+  fumadocs-ui@15.6.3(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(tailwindcss@4.1.11):
     dependencies:
       '@radix-ui/react-accordion': 1.2.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@radix-ui/react-collapsible': 1.1.11(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -7332,7 +7362,7 @@ snapshots:
       '@radix-ui/react-slot': 1.2.3(@types/react@19.1.8)(react@19.1.0)
       '@radix-ui/react-tabs': 1.1.12(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       class-variance-authority: 0.7.1
-      fumadocs-core: 15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      fumadocs-core: 15.6.3(@types/react@19.1.8)(next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       lodash.merge: 4.6.2
       next-themes: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       postcss-selector-parser: 7.1.0
@@ -7343,7 +7373,7 @@ snapshots:
       tailwind-merge: 3.3.1
     optionalDependencies:
       '@types/react': 19.1.8
-      next: 15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      next: 15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       tailwindcss: 4.1.11
     transitivePeerDependencies:
       - '@oramacloud/client'
@@ -8363,7 +8393,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  next@15.5.22(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next@15.5.22(@opentelemetry/api@1.9.0)(@playwright/test@1.62.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@next/env': 15.5.22
       '@swc/helpers': 0.5.15
@@ -8382,6 +8412,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 15.5.22
       '@next/swc-win32-x64-msvc': 15.5.22
       '@opentelemetry/api': 1.9.0
+      '@playwright/test': 1.62.1
       sharp: 0.34.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -8529,6 +8560,14 @@ snapshots:
   picomatch@4.0.3: {}
 
   pify@4.0.1: {}
+
+  playwright-core@1.62.1: {}
+
+  playwright@1.62.1:
+    dependencies:
+      playwright-core: 1.62.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   possible-typed-array-names@1.1.0: {}
 


### PR DESCRIPTION
Adds the browser-level test layer to mentis. **Testing infrastructure only — zero changes under `packages/mentis/src/`.**

## Why

mentis is a contentEditable library: its behaviour *is* caret position, `Selection`/`Range`, native editing and the clipboard. The existing vitest + happy-dom suite only approximates all four.

The history shows the cost. Commit `a6fcfd0`, *"fix: insert Enter newlines without execCommand in test DOMs"*, changed production code to satisfy the fake DOM rather than to fix anything for a user. When the test environment dictates production code, it has stopped being a source of truth.

So the layering is now explicit, and written into `e2e/README.md`:

| Layer | Tool | Owns | Must **not** assert |
|---|---|---|---|
| Unit | vitest, no DOM | pure functions: trigger detection, offset math, parsing | anything needing a real caret |
| Component | vitest + happy-dom | props → callbacks → rendered output | caret, native editing, clipboard |
| **E2E** (new) | Playwright, real browsers | caret after every operation, native editing, undo/redo, clipboard, mobile, a11y tree | — |

## What's here

- **A dedicated harness page** (`playground/e2e.html`), separate from the demo playground — `App.tsx` is a scratchpad that changes freely and tests must not depend on it. One `MentionInput` per prop configuration, each with a stable testid and its latest `onChange` payload rendered as JSON with a change counter, so specs wait for the next payload instead of racing the current one. It serves on **port 5273**, not vite's 5173, so a run can never accidentally attach to a playground left open in development.
- **Fixtures** (`e2e/fixtures/harness.ts`) — page object with `typeText` (real key events, never `fill()`), a `pressKeys("@al{ArrowDown}{Enter}")` script parser, the `onChange` readers, three clipboard paths, and **`getCaretOffset()`**: the caret as a character offset into the editor's `textContent`, read from `window.getSelection()`. That is the assertion happy-dom cannot give us and the reason this layer exists.
- **`e2e/spec/`** — one file per page in `packages/docs/content/docs/`. The docs are the spec, so documentation drift fails the build.
- **`e2e/regressions/`** — `_template.spec.ts` plus the convention, so *"add an e2e test to prevent this in future"* has one deterministic outcome. Spelled out in `e2e/README.md`, including when to push a bug **down** to vitest instead.
- **`e2e/CLAUDE.md`** — a short pointer file. Its job is to make the "pin bugs with `test.fixme`, never edit `packages/mentis/src`" constraint unmissable to an agent that has just seen a red test.
- **CI** (`.github/workflows/e2e.yml`) — chromium on PRs, full matrix incl. mobile nightly, browsers cached by Playwright version. `unit-test.yml` untouched.

## Verification, from a clean `pnpm install`

- `pnpm test:e2e` — **218 passed, 66 skipped**, green on chromium, firefox, webkit and mobile-chrome. 71 specs per project: **56 active, 15 `test.fixme`**.
- `pnpm --filter mentis test` — **86 passed, 5 todo**, identical to baseline.
- `git diff main --name-only -- packages/mentis/src/` — **empty**.

## Two findings that shaped the fixtures

- **Firefox drops `clipboardData` from a constructed `ClipboardEvent`**, so the synthetic paste path cannot run there — and paste is where the worst bug is. Added `pasteByCopying()`, which copies from a source element on the harness and pastes with real key presses: no permissions, no synthetic event, both clipboard flavours, passes on all four projects.
- **Caret offsets are not portable across a newline.** Firefox inserts a literal `"\n"` that counts in `textContent`; Chromium and WebKit use a block boundary that does not. Same visible caret, offset differs by one per newline. `expectCaretAtEnd()` exists for that case, so newline specs assert the library rather than a browser quirk.

## The 15 `test.fixme` — this is the bug backlog

Each names its cause in a comment. Nothing was fixed. `grep -rn "test.fixme" e2e/`

**Data corruption**
- **Pasting text whose mention is not at offset 0 duplicates the text and creates no chips.** `parseMentionsInText` appends the leading text then skips chip creation entirely without advancing `lastIndex`. `"hey @Alice and @Bob"` → `"hey hey @Alice and hey @Alice and @Bob"`. Hits both clipboard paths. The worst one here.
- `autoConvertMentions` writes the *label* into `data-value` instead of the option's value — chip looks right, data is wrong.
- Option values where one is a prefix of another collide in `reconstructFromDataValue`: `"user10"` yields an `Ann` chip (`user1`) plus a stray `"0"`.
- Emptying the editor reports `"\n"`, not `""` — the browser's filler `<br>` is counted before it is stripped.

**Caret and editing**
- **Typing immediately before a chip destroys the chip and swallows the character**, because chips are inserted `contenteditable="true"`.
- **Controlled `displayValue` resets the caret to offset 0 once content contains a newline**, so the next character lands at the start of the input. `dataValue` mode is unaffected.
- Native undo cannot revert a chip insertion; the typed query is gone and unrecoverable.
- One Enter is reported as two newlines.

**Documented but not true**
- Multi-character triggers (`"::"`) never match — `detectMentionTrigger` hard-codes a one-character trigger. props.mdx documents them explicitly.
- `onKeyDown` never receives Enter even with the modal closed, so props.mdx's form-submission pattern cannot be implemented.
- Dropdown-inserted chips are `contenteditable="true"`; chips.mdx says `false`, and `dataValue`-restored chips *are* `false`.
- Escape does not close the modal when no options match; and dismissal does not stick — the next keystroke reopens it.
- `container` and `option` classNames *replace* the default class while the others extend it. For the container that is functional: it drops the `position: relative` the dropdown is positioned against.
- `autoConvertMentions` never fires `onChange` for the conversion it performs.

Two pure documentation errors, no code involved: chips.mdx's chip-deletion example (`Result: "@John DoeX"`) contradicts its own prose, and one snippet passes `chipClassName` as a top-level prop instead of inside `slotsProps`.

The duplicate-label case turned out **not** to be broken for selection — distinct ids, correct `aria-selected`, correct value chosen — so that is pinned as a passing spec, and the real defect isolated to the value-prefix collision.

## Note on scope

`.gitignore`'s `CLAUDE.md` pattern has no slash, so it matched at any depth and would have hidden `e2e/CLAUDE.md` too. Negated for that one path: the root `CLAUDE.md` stays personal and local. Revert the `!e2e/CLAUDE.md` line if you would rather it stayed local too.

The first commit on this branch (`e91a0c6`) is the brief this work was executed from, at `docs/prompts/e2e-harness.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)