### PR TITLE
feat(engine): verify ADR 0009 against a real composition

### DIFF
--- a/packages/engine/docs/adr/0009-yield-the-dom-during-composition.md
+++ b/packages/engine/docs/adr/0009-yield-the-dom-during-composition.md
@@ -1,6 +1,6 @@
 # 0009 — The engine yields the DOM during composition
 
-- **Status:** accepted, **unverified against a real IME**
+- **Status:** accepted, **verified against a real composition on Chromium** (2026-08-10)
 - **Date:** 2026-08-06
 
 ## Context
@@ -86,7 +86,47 @@ Costs and risks:
 - Structure the browser leaves behind is discarded rather than understood. If a browser
   ever encodes something meaningful in it, that meaning is lost.
 
-## Unverified — and this is the important part
+## Verification, 2026-08-10
+
+**A real composition has now driven this**, through CDP
+(`e2e/spec/adr-0009-composition.spec.ts`). `Input.imeSetComposition` makes Chromium render
+its own pre-edit text and fire genuine `compositionstart` / `compositionupdate`, which is
+the window this ADR hands the DOM over for. Nothing is faked at the DOM level, and the
+contract held on first contact:
+
+- pre-edit text is rendered **by the browser** and visible in the DOM while the model has
+  deliberately not moved — the proof that `beforeinput` really is being let through, and
+  the failure mode where composition simply does not work
+- `compositionend` reconciles, and the model and DOM agree afterwards
+- **a whole composition is one undo step**, across several candidate changes
+- the DOM comes back canonical: one text node, no wrapper the browser invented
+- a mention beside the composition survives with its `value`, which is `readDomState`
+  rebuilding atoms from `data-mention-value` and the reason that attribute exists
+- committing an emoji does not split it — the path the M6 `diffDocs` surrogate bug was
+  actually reachable from
+- **no stray `insertCompositionText` is reported unhandled**, so the prediction below
+  about a trailing `beforeinput` does not hold on Chromium
+
+That retires the headline doubt this ADR has carried since M4.
+
+## Still unverified
+
+**One engine is not every engine.** Playwright can drive composition through CDP in
+Chromium only, so this is Chromium's idea of the event sequence. Specifically still
+untested:
+
+- Japanese and Chinese input on **WebKit and Firefox**, which have no CDP equivalent
+- **Gboard on Android**, which composes far more aggressively and is the case this ADR
+  called out as the aggressive one
+- iOS dictation and autocorrect
+- whether a trailing `beforeinput` arrives after `compositionend` on *those* engines — it
+  does not on Chromium, but that is where the doubt was cheapest to remove, not where it
+  was largest
+
+A human at a keyboard with a Japanese input source is still the only way to close those,
+and the harness on port 5280 is where to do it.
+
+## Original unverified note, kept for the record
 
 **None of this has met a real IME.** The tests play the browser's part by hand: fire
 `compositionstart`, write to the DOM as an IME might, fire `compositionend`, assert the

--- a/packages/engine/docs/plan.md
+++ b/packages/engine/docs/plan.md
@@ -209,10 +209,15 @@ real failure.
 > on every keystroke. The difference is scope: one composition, one writer, diffed against a
 > model that was correct going in, canonical DOM restored immediately after.
 >
-> **Nothing here has met a real IME.** The tests play the browser's part by hand, which
-> verifies the reconciliation contract and nothing about real event ordering. Revisit the ADR
-> after the first session with a Japanese input source — that is the timebox check, and it
-> needs a human at a keyboard.
+> **Verified against a real composition on 2026-08-10**, once M6's browser matrix made it
+> reachable: CDP's `Input.imeSetComposition` drives genuine `compositionstart`/`update`
+> events and Chromium renders its own pre-edit text. The contract held on first contact —
+> one undo step per composition, canonical DOM restored, a neighbouring mention keeping its
+> `value`, and no stray `insertCompositionText`. See
+> [ADR 0009](adr/0009-yield-the-dom-during-composition.md).
+>
+> **Chromium only**, though: WebKit and Firefox have no CDP equivalent, and Gboard — the
+> aggressive case this milestone was most worried about — still needs a human at a keyboard.
 
 ### M5 — Clipboard as a serialisation problem
 
@@ -397,7 +402,7 @@ pnpm install          # worktrees don't share node_modules
 - [x] M2 — atomic nodes / mentions
 - [x] M2.5 — trigger detection + dropdown
 - [x] M3 — undo stack
-- [x] M4 — IME / composition *(unverified against a real IME)*
+- [x] M4 — IME / composition *(verified on Chromium; WebKit, Firefox and Gboard outstanding)*
 - [x] M5 — clipboard *(round trip unverified against a real clipboard)*
 - [ ] M6 — nasty-input gauntlet *(graphemes and the browser matrix done; bidi and mobile input outstanding)*
 - [ ] M7 — adapters

--- a/packages/engine/e2e/README.md
+++ b/packages/engine/e2e/README.md
@@ -34,6 +34,7 @@ port-of-its-own convention, same "observe, don't fix" discipline. See `e2e/CLAUD
 | `adr-0001-newlines.spec.ts` | one `\n` per break, rendered as text, one trailing `<br>` |
 | `adr-0005-atoms.spec.ts` | a chip is one caret stop; the two coordinate spaces diverge |
 | `adr-0010-clipboard.spec.ts` | the round trip, through a real system clipboard |
+| `adr-0009-composition.spec.ts` | IME reconciliation, on a real composition (Chromium) |
 | `adr-0013-graphemes.spec.ts` | whole characters, on the browser's own ranges |
 
 The mirroring is the point. Every ADR carries an **Unverified** section, and this is where
@@ -90,7 +91,7 @@ its own ADR, not a patch.
 
 ## Not covered yet
 
-- **IME / composition (ADR 0009).** Still the oldest unverified claim in the package.
-  Playwright can drive composition through CDP in Chromium, which would cover some of it;
-  Japanese and Chinese input on WebKit, and Gboard, still need a human.
-- **RTL / bidi**, and **iOS dictation / Android word-level replacement** — the rest of M6.
+- **IME on WebKit and Firefox.** `adr-0009-composition.spec.ts` drives a real composition
+  through CDP, which is Chromium-only; the other two engines have no equivalent, so those
+  specs skip there. Gboard and iOS dictation still need a human at the harness on 5280.
+- **RTL / bidi**, and **Android word-level replacement** — the rest of M6.

--- a/packages/engine/e2e/fixtures/harness.ts
+++ b/packages/engine/e2e/fixtures/harness.ts
@@ -1,4 +1,10 @@
-import { test as base, expect, type Locator, type Page } from "@playwright/test";
+import {
+  test as base,
+  expect,
+  type CDPSession,
+  type Locator,
+  type Page,
+} from "@playwright/test";
 // Type-only, so importing the harness page here never executes it. The page owns these
 // definitions and the global declaration; duplicating them is how the two drift apart.
 import type { Content, HarnessModel, HarnessNode } from "../../dev/e2e";
@@ -189,6 +195,61 @@ export class EngineHarness {
   async paste(): Promise<void> {
     await this.ensureFocused();
     await this.page.keyboard.press(`${MODIFIER}+v`);
+  }
+
+  // --- composition ---------------------------------------------------------
+
+  /*
+   * IME composition, driven through CDP.
+   *
+   * **Chromium only** — there is no equivalent in Playwright for Firefox or WebKit, so
+   * specs using these must `test.skip` elsewhere. That is a real limit: it exercises the
+   * reconciliation contract against a genuine composition, which is far more than the
+   * unit tests could reach, but it is one engine's idea of the event sequence rather than
+   * proof that all of them agree. ADR 0009 says so.
+   *
+   * Nothing here is faked at the DOM level. `Input.imeSetComposition` makes the browser
+   * render its own pre-edit text and fire real `compositionstart`/`compositionupdate`,
+   * which is precisely the window ADR 0009 hands the DOM over for.
+   */
+
+  private cdp: CDPSession | null = null;
+
+  private async session(): Promise<CDPSession> {
+    this.cdp ??= await this.page.context().newCDPSession(this.page);
+    return this.cdp;
+  }
+
+  /** Show pre-edit text, as an IME does before you pick a candidate. */
+  async compose(text: string, caret: number = text.length): Promise<void> {
+    await this.ensureFocused();
+    const cdp = await this.session();
+    await cdp.send("Input.imeSetComposition", {
+      text,
+      selectionStart: caret,
+      selectionEnd: caret,
+    });
+  }
+
+  /** Commit the composition — picking the candidate. Fires `compositionend`. */
+  async commitComposition(text: string): Promise<void> {
+    const cdp = await this.session();
+    await cdp.send("Input.insertText", { text });
+  }
+
+  /** Abandon it, the way Escape does mid-composition. */
+  async cancelComposition(): Promise<void> {
+    const cdp = await this.session();
+    await cdp.send("Input.imeSetComposition", {
+      text: "",
+      selectionStart: 0,
+      selectionEnd: 0,
+    });
+  }
+
+  /** Whether the engine currently believes the browser owns the DOM. */
+  async isComposing(): Promise<boolean> {
+    return (await this.model()).composing;
   }
 
   // --- assertions ----------------------------------------------------------

--- a/packages/engine/e2e/spec/adr-0009-composition.spec.ts
+++ b/packages/engine/e2e/spec/adr-0009-composition.spec.ts
@@ -1,0 +1,211 @@
+import { expect, test } from "../fixtures/harness";
+
+/**
+ * ADR 0009 — the engine yields the DOM during composition.
+ *
+ * This has been the package's oldest unverified claim since M4. The ADR is blunt about it:
+ *
+ * > **None of this has met a real IME.** The tests play the browser's part by hand: fire
+ * > `compositionstart`, write to the DOM as an IME might, fire `compositionend`, assert
+ * > the model caught up. That verifies the reconciliation *contract*. It does not verify
+ * > that real IMEs emit these events in this order, or write this shape of DOM.
+ *
+ * These specs verify exactly that. `Input.imeSetComposition` makes Chromium render its own
+ * pre-edit text and fire genuine `compositionstart` / `compositionupdate`, which is the
+ * window ADR 0009 hands the DOM over for. Nothing is faked at the DOM level.
+ *
+ * **Chromium only.** Playwright has no equivalent for Firefox or WebKit, so this is one
+ * engine's idea of the event sequence rather than proof that all of them agree. Japanese
+ * and Chinese input on WebKit, and Gboard, still need a human — the ADR keeps saying so.
+ */
+
+test.skip(
+  ({ browserName }) => browserName !== "chromium",
+  "CDP composition is Chromium only"
+);
+
+const ALICE = { label: "@Alice", value: "u_1" };
+
+test("a committed composition lands in the model", async ({ harness }) => {
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+
+  await harness.compose("にほんg");
+  await harness.commitComposition("日本語");
+
+  await harness.expectText("hi 日本語");
+  await harness.expectModelMatchesDom();
+});
+
+test("the engine yields the DOM for the duration and takes it back", async ({
+  harness,
+}) => {
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+
+  expect(await harness.isComposing()).toBe(false);
+
+  await harness.compose("にほん");
+  // The model is knowingly stale here — this is the one window where the DOM leads.
+  expect(await harness.isComposing()).toBe(true);
+
+  await harness.commitComposition("日本");
+
+  expect(await harness.isComposing()).toBe(false);
+  await harness.expectModelMatchesDom();
+});
+
+test("pre-edit text really is rendered by the browser, not by us", async ({
+  harness,
+}) => {
+  // If the engine were still preventing `beforeinput` during composition, nothing would
+  // appear here at all — which is the failure ADR 0009 exists to avoid. The DOM shows the
+  // pre-edit text while the model has not moved.
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+
+  await harness.compose("にほん");
+
+  expect(await harness.domText()).toContain("にほん");
+  expect(await harness.text()).toBe("hi ");
+
+  await harness.commitComposition("日本");
+  await harness.expectModelMatchesDom();
+});
+
+test("a whole composition is a single undo step", async ({ harness }) => {
+  // The claim that makes the reconciliation worth doing at all: `diffDocs` narrows the
+  // whole composition to one transaction, so undo does not walk back through candidates.
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+  const before = (await harness.model()).history.depth;
+
+  await harness.compose("に");
+  await harness.compose("にほ");
+  await harness.compose("にほん");
+  await harness.commitComposition("日本語");
+
+  await harness.expectText("hi 日本語");
+  expect((await harness.model()).history.depth).toBe(before + 1);
+
+  await harness.undo();
+  await harness.expectText("hi ");
+});
+
+test("the DOM is restored to canonical form afterwards", async ({ harness }) => {
+  // The browser invents wrapper elements while it owns the DOM. `render` discards them,
+  // which is what keeps the one-node-per-child invariant that position mapping needs.
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+
+  await harness.compose("にほん");
+  await harness.commitComposition("日本");
+
+  const childKinds = await harness.editor.evaluate((element) =>
+    Array.from(element.childNodes).map((node) => node.nodeName)
+  );
+  expect(childKinds).toEqual(["#text"]);
+});
+
+test("a cancelled composition leaves the document untouched", async ({ harness }) => {
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+
+  await harness.compose("にほん");
+  await harness.cancelComposition();
+
+  await harness.expectText("hi ");
+  await harness.expectModelMatchesDom();
+  expect(await harness.isComposing()).toBe(false);
+});
+
+test("a mention survives a composition beside it", async ({ harness }) => {
+  // The risky part of the reconcile: `readDomState` rebuilds atoms from the DOM, and the
+  // only thing that makes that possible is `data-mention-value` living on the element.
+  // Lose it and a chip silently degrades to its label — the exact failure ADR 0005 and
+  // ADR 0010 both guard against, arriving by a third route.
+  await harness.reset(["hi ", ALICE, " "]);
+  await harness.setCaretToEnd();
+
+  await harness.compose("にほん");
+  await harness.commitComposition("日本");
+
+  await harness.expectText("hi @Alice 日本");
+  expect((await harness.model()).mentions).toEqual([
+    { label: "@Alice", value: "u_1", at: 3 },
+  ]);
+  await expect(harness.chips()).toHaveCount(1);
+  await harness.expectModelMatchesDom();
+});
+
+test("a composition before a mention does not disturb it", async ({ harness }) => {
+  await harness.reset(["hi ", ALICE]);
+  await harness.setCaret(3);
+
+  await harness.compose("にほん");
+  await harness.commitComposition("日本");
+
+  await harness.expectText("hi 日本@Alice");
+  expect((await harness.model()).mentions).toEqual([
+    { label: "@Alice", value: "u_1", at: 5 },
+  ]);
+});
+
+test("a composition committing an emoji does not split it", async ({ harness }) => {
+  // This is the path the M6 `diffDocs` bug was actually reachable from: the reconcile
+  // compares old and new text code unit by code unit, and two emoji sharing a surrogate
+  // used to produce a lone one. Now reachable through a real composition rather than a
+  // hand-fired event.
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+
+  await harness.compose(":thumbs");
+  await harness.commitComposition("\u{1F44D}");
+
+  await harness.expectText("hi \u{1F44D}");
+  expect((await harness.model()).length).toBe(5);
+  await harness.expectModelMatchesDom();
+});
+
+test("replacing one emoji with another through composition stays whole", async ({
+  harness,
+}) => {
+  await harness.reset(["\u{1F44D}"]);
+  await harness.setCaretToEnd();
+
+  await harness.press("{Backspace}");
+  await harness.compose(":thumbsdown");
+  await harness.commitComposition("\u{1F44E}");
+
+  await harness.expectText("\u{1F44E}");
+  await harness.expectModelMatchesDom();
+});
+
+test("typing continues normally after a composition", async ({ harness }) => {
+  await harness.reset([]);
+
+  await harness.compose("にほん");
+  await harness.commitComposition("日本");
+  await harness.type("!");
+
+  await harness.expectText("日本!");
+  await harness.expectCaret(3);
+  await harness.expectModelMatchesDom();
+  expect(await harness.unhandledInput()).toEqual([]);
+});
+
+test("no stray insertCompositionText reaches the engine unhandled", async ({
+  harness,
+}) => {
+  // ADR 0009 removed `insertCompositionText` from the insertion set, on the reasoning that
+  // handling it there *as well* would apply the composed text twice. A stray one is
+  // reported rather than guessed at — so an empty list here is the ADR's prediction
+  // holding, and a non-empty one is the trailing-beforeinput case it flagged as possible.
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+
+  await harness.compose("にほん");
+  await harness.commitComposition("日本");
+
+  expect(await harness.unhandledInput()).toEqual([]);
+});


### PR DESCRIPTION
Closes the **oldest unverified claim in the package** — on Chromium.

ADR 0009 has said since M4:

> **None of this has met a real IME.** The tests play the browser's part by hand... That verifies the reconciliation *contract*. It does not verify that real IMEs emit these events in this order, or write this shape of DOM.

The matrix landing in #88 is what made the difference. CDP's `Input.imeSetComposition` makes Chromium render its **own** pre-edit text and fire genuine `compositionstart` / `compositionupdate` — exactly the window ADR 0009 hands the DOM over for. Nothing is faked at the DOM level.

**The contract held on first contact.** Twelve specs, all green:

| Spec | Why it matters |
|---|---|
| pre-edit text is rendered **by the browser**, model deliberately unmoved | Direct evidence `beforeinput` is being let through. The alternative isn't degraded composition — it's none at all. |
| `compositionend` reconciles, model and DOM agree | The reconciliation contract itself |
| **one undo step** across several candidate changes | The claim that makes reconciling worth doing instead of replacing the document |
| DOM comes back canonical — one text node, no invented wrapper | The one-node-per-child invariant position mapping needs |
| a neighbouring mention keeps its `value` | `readDomState` rebuilding atoms from `data-mention-value` — the whole reason that attribute exists |
| committing an emoji doesn't split it | The path M6's `diffDocs` surrogate bug was **actually reachable from**, now through a real composition rather than a hand-fired event |
| no stray `insertCompositionText` reported unhandled | The trailing-`beforeinput` case the ADR flagged as possible doesn't occur here |

## Still unverified — and worth being plain about

**The doubt was removed where it was cheapest to remove, not where it was largest.**

Playwright drives composition through CDP in **Chromium only**, so this is one engine's idea of the event sequence. WebKit and Firefox have no equivalent and those specs skip there. **Gboard** — the aggressive case this milestone was most worried about, the one that composes whole words as a matter of course — and iOS dictation still need a human at the harness on 5280.

ADR 0009's status line now reads *"verified against a real composition on Chromium"* rather than *"unverified against a real IME"*, and its Unverified section says which is which instead of "none of this". The original note is kept below it for the record.

## Numbers

152 passing, 36 skipped across the matrix. 418 unit tests unchanged.

The skips are the 3 delete-granularity `test.fixme`s plus the 12 Chromium-only composition specs, times the projects that skip them.

## Test by hand

Two things, and the second is the one that matters.

1. `pnpm --filter @mentis/engine test:e2e` — expect `152 passed, 36 skipped`.

2. **Switch to a Japanese input source and type into the harness yourself**, on port 5280 (`pnpm --filter @mentis/engine dev:e2e`), and then do it again in **Safari**. Type `nihongo`, cycle candidates with the arrow keys, commit with Enter. Watch the Model panel keep up, then press ⌘Z once and confirm the whole composition disappears in one step.

   That is the check CDP cannot do for you: it settles WebKit, which has no automated path at all and where the event ordering is genuinely different. If it works there, the remaining gap is Gboard alone.

   Worth also composing *immediately after a chip* — that exercises `readDomState` rebuilding the atom, which is the part most likely to break on an engine I haven't tested.
