### PR TITLE
chore: optimise mentis for search and AI discovery

### DIFF
--- a/.changeset/olive-donkeys-shave.md
+++ b/.changeset/olive-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+"mentis": patch
+---
+
+Rewrite the npm package description and keywords so the package is discoverable as a maintained `react-mentions` alternative. No runtime changes — a release is needed for the new metadata to reach the npm registry.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,14 @@
   <img src="https://mentis.alexdunlop.com/_next/image?url=%2Flogo%2Flogo.png&w=256&q=75" width="200" alt="Mentis" />
   <h1>Mentis</h1>
   <p>
-    <strong>A flexible mention tagger for React that hooks into your existing inputs.</strong>
+    <strong>Accessible <code>@mention</code> autocomplete input for React.</strong>
+    <br />
+    ContentEditable, zero dependencies, TypeScript-first.
   </p>
   <p>
     <a href="https://mentis.alexdunlop.com/"><strong>📖 Read the docs »</strong></a>
+    &nbsp;·&nbsp;
+    <a href="https://mentis.alexdunlop.com/"><strong>▶️ Live demo »</strong></a>
   </p>
 </div>
 
@@ -28,6 +32,38 @@
 </div>
 
 <br />
+
+**Mentis** adds Slack- and Notion-style `@mention` autocomplete to a React app. You give it a list of options, it gives you an input where typing `@` opens a filtered dropdown and picking someone inserts a styled chip. `onChange` hands back both what the user sees (`displayValue`) and the clean IDs you want to store (`dataValue`), so you never have to parse mention syntax yourself.
+
+It's built on `contentEditable` rather than a plain `<textarea>`, which is what makes real chips, caret navigation through mentions, and paste handling possible. It ships with full ARIA `combobox` semantics, TypeScript types, and no runtime dependencies.
+
+## Why Mentis?
+
+[`react-mentions`](https://www.npmjs.com/package/react-mentions) has been the default choice for years, but it hasn't seen a release since 2022 and is built on a `<textarea>` + overlay approach that can't render true chips. Mentis is a maintained, modern alternative:
+
+|                              | Mentis                        | react-mentions          |
+| ---------------------------- | ----------------------------- | ----------------------- |
+| Last release                 | Actively maintained           | 2022                    |
+| Foundation                   | `contentEditable`             | `<textarea>` + overlay  |
+| Mentions render as chips     | ✅ Real DOM elements          | ❌ Styled text overlay  |
+| Runtime dependencies         | ✅ Zero                       | `substyle`, others      |
+| TypeScript types             | ✅ Built in                   | `@types/react-mentions` |
+| ARIA combobox / screenreader | ✅ Full                       | Partial                 |
+| React 19 support             | ✅                            | Unmaintained            |
+| Separate display / data       | ✅ `displayValue`/`dataValue` | Manual markup parsing   |
+
+If you're searching for a **react-mentions alternative**, a **React mentions input**, an **@mention autocomplete**, or a **tagging / typeahead input** — that's what this is.
+
+## Table of Contents
+
+- [Features](#features)
+- [Quick Start](#quick-start)
+- [Examples](#examples)
+- [API Reference](#api-reference)
+- [Keyboard Navigation](#keyboard-navigation)
+- [Advanced Features](#advanced-features)
+- [FAQ](#faq)
+- [For AI assistants and LLMs](#for-ai-assistants-and-llms)
 
 ## Features
 
@@ -101,14 +137,17 @@ function BasicExample() {
 import { MentionInput } from "mentis";
 
 function FunctionValueExample() {
+  const [displayValue, setDisplayValue] = useState("");
+
   return (
     <MentionInput
+      displayValue={displayValue}
       options={[
         { label: "Send Message", value: () => console.log("Message sent!") },
-        { label: "Clear Input", value: () => setValue("") },
+        { label: "Clear Input", value: () => setDisplayValue("") },
         { label: "Alice Johnson", value: "alice" },
       ]}
-      onChange={(mentionData) => console.log(mentionData)}
+      onChange={(mentionData) => setDisplayValue(mentionData.displayValue)}
     />
   );
 }
@@ -191,17 +230,17 @@ function AutoConvertExample() {
 import { MentionInput } from "mentis";
 
 function FormSubmissionExample() {
-  const [value, setValue] = useState("");
+  const [displayValue, setDisplayValue] = useState("");
 
   const handleSubmit = () => {
-    console.log("Submitting:", value);
-    setValue("");
+    console.log("Submitting:", displayValue);
+    setDisplayValue("");
   };
 
   return (
     <MentionInput
-      value={value}
-      onChange={(mentionData) => setValue(mentionData.value)}
+      displayValue={displayValue}
+      onChange={(mentionData) => setDisplayValue(mentionData.displayValue)}
       onKeyDown={(event) => {
         // Handle Enter key for form submission
         if (event.key === "Enter") {
@@ -356,6 +395,58 @@ The component intelligently parses mentions from pasted content, converting them
 ### Rich Text Support
 
 Mentions are displayed as styled chips within the contentEditable interface, providing a rich text experience.
+
+## FAQ
+
+### How do I add @mentions to a React app?
+
+Install `mentis`, import `MentionInput` and its stylesheet, and pass an `options` array. Typing `@` opens the dropdown. See [Quick Start](#quick-start).
+
+### Is this a drop-in replacement for react-mentions?
+
+Not literally — the prop API is different (`options` instead of `<Mention data={...} />` children, and `displayValue`/`dataValue` instead of a single markup string). But it covers the same use cases with less setup, and you don't have to parse `@[name](id)` markup yourself. See [Why Mentis?](#why-mentis).
+
+### Can I use a trigger other than `@`?
+
+Yes. Pass `trigger="#"` (or any string) to change it. Useful for hashtags, slash commands, or `$` for entities.
+
+### Does it work with Next.js and React Server Components?
+
+Yes. `MentionInput` is a client component, so import it from a file with `"use client"` (or a component that already has it). There's a [Next.js example](https://github.com/Alexanderdunlop/mentis/tree/main/packages/examples/nextjs).
+
+### Can I style it with Tailwind?
+
+Yes. Every part is styled via `slotsProps` — pass Tailwind classes to `container`, `contentEditable`, `modal`, `option`, `chipClassName`, and `highlightedClassName`. See [Custom Styling with Tailwind](#custom-styling-with-tailwind).
+
+### How do I store mentions in a database?
+
+Use `dataValue` from `onChange` — it contains your option IDs instead of display labels. Store that, then pass it back as the `dataValue` prop later to rehydrate the input with chips. See [DataValue Control](#datavalue-control).
+
+### Does it support TypeScript?
+
+Yes, types ship in the package — no `@types/*` install needed. `MentionInputProps`, `MentionOption`, `MentionData`, and `SlotProps` are all exported.
+
+### Is it accessible?
+
+Yes. It implements the ARIA `combobox`/`listbox`/`option` pattern with full keyboard navigation and screen reader support. See [Accessibility](https://mentis.alexdunlop.com/docs/accessibility).
+
+### How big is it?
+
+Zero runtime dependencies, and React is a peer dependency. See the [bundle size badge](https://bundlephobia.com/package/mentis) for the current number.
+
+### Does it support multiple mention types in one input?
+
+A single `MentionInput` has one `trigger`, but `options` can mix entity kinds, and option values can be functions to trigger actions instead of inserting a chip. See [Function Values](#function-values).
+
+## For AI assistants and LLMs
+
+If you're an AI coding assistant, or you're pointing one at this library, these are the machine-readable entry points:
+
+- [`/llms.txt`](https://mentis.alexdunlop.com/llms.txt) — index of every documentation page
+- [`/llms-full.txt`](https://mentis.alexdunlop.com/llms-full.txt) — the full documentation as a single plaintext file
+- [LLM Context page](https://mentis.alexdunlop.com/docs/llm) — architecture, types, and implementation notes
+
+The two props most often got wrong: the controlled value props are `displayValue` (what the user sees, with labels) and `dataValue` (IDs for storage). There is no plain `value` prop.
 
 ## Examples Directory
 

--- a/packages/docs/content/docs/basic-usage.mdx
+++ b/packages/docs/content/docs/basic-usage.mdx
@@ -1,5 +1,6 @@
 ---
 title: Basic usage
+description: A minimal controlled MentionInput example in React, with options, displayValue, dataValue, and onChange.
 ---
 
 import { MentisDemo } from "@/components";

--- a/packages/docs/content/docs/examples.mdx
+++ b/packages/docs/content/docs/examples.mdx
@@ -1,5 +1,6 @@
 ---
 title: Examples
+description: "Runnable mentis example apps: plain React, custom CSS, Tailwind, Next.js, and the Vercel AI SDK."
 ---
 
 Explore various usage examples for this library.

--- a/packages/docs/content/docs/llm.mdx
+++ b/packages/docs/content/docs/llm.mdx
@@ -5,11 +5,22 @@ description: "Comprehensive context about the mentis library for AI assistants a
 
 # Mentis Library Context for LLMs
 
-This document provides comprehensive context about the `@/mentis` library for AI assistants and LLMs to understand the codebase architecture, features, and implementation details.
+This document provides comprehensive context about the `mentis` library for AI assistants and LLMs to understand the codebase architecture, features, and implementation details.
+
+Machine-readable versions of the full documentation are available at [`/llms.txt`](https://mentis.alexdunlop.com/llms.txt) and [`/llms-full.txt`](https://mentis.alexdunlop.com/llms-full.txt).
 
 ## Overview
 
 **Mentis** is a modern React library for implementing mention/tagging functionality in text inputs. It's designed to be flexible, accessible, and highly customizable with support for both string and function values.
+
+Install it as `mentis` (not `@mentis/react`) and import the stylesheet alongside the component:
+
+```tsx
+import { MentionInput } from "mentis";
+import "mentis/dist/index.css";
+```
+
+It is commonly reached for as a maintained alternative to `react-mentions`, which was last released in 2022 and is built on a `<textarea>` overlay rather than `contentEditable`.
 
 ## Core Architecture
 
@@ -90,7 +101,7 @@ type MentionOption = {
 };
 
 type MentionData = {
-  value: string; // Text as shown to user
+  displayValue: string; // Text as shown to user (with mention labels)
   dataValue: string; // Text with mention values (actual data)
   mentions: Array<{
     label: string;
@@ -101,7 +112,8 @@ type MentionData = {
 };
 
 type MentionInputProps = {
-  value?: string;
+  displayValue?: string; // Controlled display text — NOTE: there is no plain `value` prop
+  dataValue?: string; // Controlled data text (mention IDs)
   options: MentionOption[];
   slotsProps?: SlotProps;
   keepTriggerOnSelect?: boolean;
@@ -244,10 +256,10 @@ When an option with a function value is selected:
 <MentionInput
   options={[
     { label: "Send Message", value: () => console.log("Message sent!") },
-    { label: "Clear Input", value: () => setValue("") },
+    { label: "Clear Input", value: () => setDisplayValue("") },
     { label: "Alice Johnson", value: "alice" },
   ]}
-  onChange={(mentionData) => setValue(mentionData.value)}
+  onChange={(mentionData) => setDisplayValue(mentionData.displayValue)}
 />
 ```
 
@@ -345,4 +357,10 @@ When an option with a function value is selected:
 
 This library represents a modern, well-architected solution for mention functionality that prioritizes accessibility, customization, and developer experience with support for both traditional mentions and dynamic function execution.
 
-Updated 2025-07-23 - v0.2.0-alpha.2
+## Common Mistakes
+
+- **There is no `value` prop.** The controlled props are `displayValue` (labels the user sees) and `dataValue` (option IDs for storage).
+- **`onChange` receives a `MentionData` object, not a string.** Use `onChange={(data) => setDisplayValue(data.displayValue)}`.
+- **The package is `mentis`.** Not `@mentis/react`, not `react-mentis`.
+- **Import the stylesheet.** `import "mentis/dist/index.css"` — chips and the dropdown are unstyled without it.
+- **`MentionInput` is a client component.** Under the Next.js App Router it needs `"use client"`.

--- a/packages/docs/content/docs/onchange.mdx
+++ b/packages/docs/content/docs/onchange.mdx
@@ -1,5 +1,6 @@
 ---
 title: onChange Callback
+description: "How the mentis onChange callback works: the MentionData object, displayValue vs dataValue, and the mentions array."
 ---
 
 The `onChange` callback in Mentis provides you with both the display text and structured mention data. This allows you to access the actual mention values for processing, validation, or API calls.

--- a/packages/docs/content/docs/props.mdx
+++ b/packages/docs/content/docs/props.mdx
@@ -155,21 +155,21 @@ Here's how to handle form submission when the user presses Enter (but only when 
 
 ```tsx
 import { useState } from "react";
-import { MentionInput } from "@mentis/react";
+import { MentionInput } from "mentis";
 
 function ChatForm() {
-  const [value, setValue] = useState("");
+  const [displayValue, setDisplayValue] = useState("");
 
   const handleSubmit = async () => {
     console.log("submit");
-    setValue("");
+    setDisplayValue("");
   };
 
   return (
     <form onSubmit={(e) => e.preventDefault()}>
       <MentionInput
-        value={value}
-        onChange={setValue}
+        displayValue={displayValue}
+        onChange={(mentionData) => setDisplayValue(mentionData.displayValue)}
         onKeyDown={(event) => {
           // Handle Enter key for form submission
           if (event.key === "Enter") {
@@ -227,7 +227,7 @@ Options can have function values that execute when selected. This is useful for 
 <MentionInput
   options={[
     { label: "Send Message", value: () => console.log("Message sent!") },
-    { label: "Clear Input", value: () => setValue("") },
+    { label: "Clear Input", value: () => setDisplayValue("") },
     { label: "Alice", value: "alice" },
   ]}
 />

--- a/packages/docs/content/docs/styling.mdx
+++ b/packages/docs/content/docs/styling.mdx
@@ -1,5 +1,6 @@
 ---
 title: Styling & Customization
+description: Style the mentis MentionInput with Tailwind, CSS modules, or plain CSS using the slotsProps class names for each slot.
 ---
 
 import { MentisDemo } from "@/components";

--- a/packages/docs/src/app/(home)/page.tsx
+++ b/packages/docs/src/app/(home)/page.tsx
@@ -1,19 +1,62 @@
-import { Metadata } from "next";
 import { HeroSection } from "@/components";
+import {
+  createMetadata,
+  defaultTitle,
+  siteDescription,
+  siteUrl,
+} from "@/lib/metadata";
 
-export const metadata: Metadata = {
+export const metadata = {
+  ...createMetadata({ path: "/" }),
   title: {
-    absolute:
-      "mentis | A small, fast, and flexible mention input solution for React",
+    absolute: defaultTitle,
   },
-  alternates: {
-    canonical: "https://mentis.alexdunlop.com",
-  },
+};
+
+/**
+ * Structured data so search engines and AI crawlers can identify what this
+ * package is without parsing the page.
+ */
+const structuredData = {
+  "@context": "https://schema.org",
+  "@graph": [
+    {
+      "@type": "WebSite",
+      "@id": `${siteUrl}/#website`,
+      url: siteUrl,
+      name: "mentis",
+      description: siteDescription,
+      inLanguage: "en",
+    },
+    {
+      "@type": "SoftwareSourceCode",
+      "@id": `${siteUrl}/#software`,
+      name: "mentis",
+      description: siteDescription,
+      url: siteUrl,
+      codeRepository: "https://github.com/alexanderdunlop/mentis",
+      programmingLanguage: ["TypeScript", "JavaScript"],
+      runtimePlatform: "React",
+      license: "https://opensource.org/licenses/MIT",
+      author: {
+        "@type": "Person",
+        name: "Alexander Dunlop",
+        url: "https://alexdunlop.com/",
+      },
+      keywords:
+        "react mentions, mention input, @mention autocomplete, react-mentions alternative, combobox, typeahead, tagging, contenteditable, accessible",
+    },
+  ],
 };
 
 export default function HomePage() {
   return (
     <main className="flex flex-1 flex-col justify-center items-center text-center">
+      <script
+        type="application/ld+json"
+        // Static, author-controlled JSON — no user input is interpolated.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
       <HeroSection />
     </main>
   );

--- a/packages/docs/src/app/docs/[[...slug]]/page.tsx
+++ b/packages/docs/src/app/docs/[[...slug]]/page.tsx
@@ -8,6 +8,7 @@ import {
 import { notFound } from 'next/navigation';
 import { createRelativeLink } from 'fumadocs-ui/mdx';
 import { getMDXComponents } from '@/mdx-components';
+import { createMetadata } from '@/lib/metadata';
 
 export default async function Page(props: {
   params: Promise<{ slug?: string[] }>;
@@ -45,8 +46,9 @@ export async function generateMetadata(props: {
   const page = source.getPage(params.slug);
   if (!page) notFound();
 
-  return {
+  return createMetadata({
     title: page.data.title,
     description: page.data.description,
-  };
+    path: page.url,
+  });
 }

--- a/packages/docs/src/app/layout.tsx
+++ b/packages/docs/src/app/layout.tsx
@@ -3,23 +3,54 @@ import { RootProvider } from "fumadocs-ui/provider";
 import { Metadata } from "next";
 import { Inter } from "next/font/google";
 import type { ReactNode } from "react";
+import {
+  defaultTitle,
+  ogImage,
+  siteDescription,
+  siteKeywords,
+  siteName,
+  siteUrl,
+} from "@/lib/metadata";
 
 const inter = Inter({
   subsets: ["latin"],
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL(siteUrl),
   title: {
-    template: "%s | mentis",
-    default: "mentis",
+    template: `%s | ${siteName}`,
+    default: defaultTitle,
   },
-  description: "A small, fast, and flexible mention input solution for React.",
+  description: siteDescription,
+  keywords: siteKeywords,
+  applicationName: siteName,
   authors: [
     {
       name: "Alexander Dunlop",
       url: "https://alexdunlop.com/",
     },
   ],
+  creator: "Alexander Dunlop",
+  openGraph: {
+    type: "website",
+    siteName,
+    url: siteUrl,
+    title: defaultTitle,
+    description: siteDescription,
+    locale: "en_US",
+    images: [ogImage],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: defaultTitle,
+    description: siteDescription,
+    images: [ogImage],
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
 };
 
 export default function Layout({ children }: { children: ReactNode }) {

--- a/packages/docs/src/app/llms-full.txt/route.ts
+++ b/packages/docs/src/app/llms-full.txt/route.ts
@@ -1,0 +1,48 @@
+import { getDocEntries } from "@/lib/llms";
+import { siteDescription, siteUrl } from "@/lib/metadata";
+
+export const dynamic = "force-static";
+export const revalidate = false;
+
+/**
+ * Serves the entire documentation set as a single plaintext file, so a model can
+ * ingest all of it in one fetch.
+ *
+ * @see https://llmstxt.org
+ */
+export async function GET() {
+  const entries = await getDocEntries();
+
+  const sections = entries
+    .map((entry) => {
+      const header = [
+        `# ${entry.title}`,
+        entry.description ? `> ${entry.description}` : undefined,
+        `Source: ${siteUrl}${entry.url}`,
+      ]
+        .filter(Boolean)
+        .join("\n");
+
+      return `${header}\n\n${entry.content}`;
+    })
+    .join("\n\n---\n\n");
+
+  const body = `# mentis — full documentation
+
+> ${siteDescription}
+
+Package name: mentis
+Repository: https://github.com/alexanderdunlop/mentis
+Documentation: ${siteUrl}
+
+---
+
+${sections}
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/packages/docs/src/app/llms.txt/route.ts
+++ b/packages/docs/src/app/llms.txt/route.ts
@@ -1,0 +1,56 @@
+import { getDocEntries } from "@/lib/llms";
+import { siteDescription, siteUrl } from "@/lib/metadata";
+
+export const dynamic = "force-static";
+export const revalidate = false;
+
+/**
+ * Serves an llms.txt index of the documentation.
+ *
+ * @see https://llmstxt.org
+ */
+export async function GET() {
+  const entries = await getDocEntries();
+
+  const links = entries
+    .map(
+      (entry) =>
+        `- [${entry.title}](${siteUrl}${entry.url})${entry.description ? `: ${entry.description}` : ""}`,
+    )
+    .join("\n");
+
+  const body = `# mentis
+
+> ${siteDescription}
+
+mentis is a React component library that adds Slack- and Notion-style \`@mention\`
+autocomplete to an input. It is built on \`contentEditable\` so mentions render as
+real DOM chips, and it is commonly used as a maintained alternative to
+\`react-mentions\`.
+
+Install with \`npm install mentis\`. Import the component and its stylesheet:
+
+    import { MentionInput } from "mentis";
+    import "mentis/dist/index.css";
+
+The controlled props are \`displayValue\` (what the user sees) and \`dataValue\`
+(option IDs for storage). There is no plain \`value\` prop. \`onChange\` receives a
+\`MentionData\` object, not a string.
+
+## Documentation
+
+${links}
+
+## Optional
+
+- [Full documentation as plaintext](${siteUrl}/llms-full.txt): every page above concatenated into one file
+- [GitHub repository](https://github.com/alexanderdunlop/mentis): source, issues, and examples
+- [npm package](https://www.npmjs.com/package/mentis): release history and install instructions
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+    },
+  });
+}

--- a/packages/docs/src/app/opengraph-image.tsx
+++ b/packages/docs/src/app/opengraph-image.tsx
@@ -1,0 +1,98 @@
+import { ImageResponse } from "next/og";
+
+export const alt =
+  "mentis — Accessible @mention autocomplete input for React";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export const dynamic = "force-static";
+
+/**
+ * Site-wide social card. Rendered at build time by satori, so every style is
+ * inline and every multi-child element sets an explicit `display`.
+ */
+export default function OpengraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          background: "#0b0b0f",
+          backgroundImage:
+            "radial-gradient(circle at 12% 12%, #1e2a4a 0%, transparent 55%)",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <div
+          style={{
+            display: "flex",
+            fontSize: 96,
+            fontWeight: 700,
+            color: "#ffffff",
+            letterSpacing: "-0.03em",
+          }}
+        >
+          mentis
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            marginTop: 20,
+            fontSize: 40,
+            color: "#c3c8d4",
+            lineHeight: 1.3,
+          }}
+        >
+          Accessible @mention autocomplete input for React
+        </div>
+
+        {/* Faux input showing what the component actually renders. */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            marginTop: 56,
+            padding: "22px 28px",
+            borderRadius: 16,
+            border: "1px solid #2c3044",
+            background: "#14151d",
+            fontSize: 32,
+            color: "#8b91a3",
+          }}
+        >
+          <span
+            style={{
+              display: "flex",
+              padding: "6px 16px",
+              marginRight: 14,
+              borderRadius: 999,
+              background: "#3b82f6",
+              color: "#ffffff",
+            }}
+          >
+            @Alice Johnson
+          </span>
+          <span style={{ display: "flex" }}>can you take a look?</span>
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            marginTop: 48,
+            fontSize: 28,
+            color: "#6b7280",
+          }}
+        >
+          contentEditable · zero dependencies · TypeScript-first
+        </div>
+      </div>
+    ),
+    size,
+  );
+}

--- a/packages/docs/src/app/robots.ts
+++ b/packages/docs/src/app/robots.ts
@@ -1,0 +1,19 @@
+import type { MetadataRoute } from "next";
+import { siteUrl } from "@/lib/metadata";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        // Explicitly welcome AI crawlers as well as search engines — being
+        // indexed by both is how people find this package.
+        userAgent: "*",
+        allow: "/",
+      },
+    ],
+    sitemap: `${siteUrl}/sitemap.xml`,
+    host: siteUrl,
+  };
+}

--- a/packages/docs/src/app/sitemap.ts
+++ b/packages/docs/src/app/sitemap.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+import { source } from "@/lib/source";
+import { siteUrl } from "@/lib/metadata";
+
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const docs = source.getPages().map((page) => ({
+    url: `${siteUrl}${page.url}`,
+    changeFrequency: "weekly" as const,
+    priority: 0.8,
+  }));
+
+  return [
+    {
+      url: siteUrl,
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    ...docs,
+  ];
+}

--- a/packages/docs/src/lib/llms.ts
+++ b/packages/docs/src/lib/llms.ts
@@ -1,0 +1,110 @@
+import { readFile } from "node:fs/promises";
+import { source } from "@/lib/source";
+
+/**
+ * Strips MDX-only syntax so the output reads as plain Markdown.
+ *
+ * Import statements and demo components are meaningful to the site build but
+ * are noise (or actively misleading) to a model reading the docs, so they are
+ * removed. Fenced code blocks are left untouched — they contain `import` lines
+ * that are part of the documented API.
+ */
+function mdxToPlainMarkdown(raw: string): string {
+  const withoutFrontmatter = raw.replace(/^---\r?\n[\s\S]*?\r?\n---\r?\n?/, "");
+
+  const lines = withoutFrontmatter.split("\n");
+  const output: string[] = [];
+  let insideFence = false;
+  let insideJsxBlock = false;
+
+  for (const line of lines) {
+    if (/^\s*```/.test(line)) {
+      insideFence = !insideFence;
+      output.push(line);
+      continue;
+    }
+
+    if (insideFence) {
+      output.push(line);
+      continue;
+    }
+
+    // Drop a multi-line JSX demo element once it has been opened.
+    if (insideJsxBlock) {
+      if (/\/>\s*$|^\s*<\//.test(line)) insideJsxBlock = false;
+      continue;
+    }
+
+    // Local component imports, e.g. `import { MentisDemo } from "@/components";`
+    if (/^\s*import\s.+from\s+["']@\//.test(line)) continue;
+
+    // Self-closing demo elements on one line.
+    if (/^\s*<[A-Z][\w.]*[^>]*\/>\s*$/.test(line)) continue;
+
+    // Opening tag of a multi-line demo element.
+    if (/^\s*<[A-Z][\w.]*\s*$/.test(line) || /^\s*<[A-Z][\w.]*\s+[^/>]*$/.test(line)) {
+      insideJsxBlock = true;
+      continue;
+    }
+
+    output.push(line);
+  }
+
+  return output.join("\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+export interface DocEntry {
+  title: string;
+  description?: string;
+  url: string;
+  content: string;
+}
+
+/**
+ * Collects page URLs in the order they appear in the sidebar, so the generated
+ * files read top-to-bottom like the docs rather than alphabetically.
+ */
+function sidebarUrlOrder(): string[] {
+  const urls: string[] = [];
+
+  const walk = (nodes: typeof source.pageTree.children) => {
+    for (const node of nodes) {
+      if (node.type === "page") urls.push(node.url);
+      else if (node.type === "folder") walk(node.children);
+    }
+  };
+
+  walk(source.pageTree.children);
+  return urls;
+}
+
+/**
+ * Loads every documentation page in sidebar order with its Markdown body.
+ */
+export async function getDocEntries(): Promise<DocEntry[]> {
+  const order = sidebarUrlOrder();
+  const rank = (url: string) => {
+    const index = order.indexOf(url);
+    // Pages missing from the sidebar sort last rather than to the front.
+    return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+  };
+
+  const pages = [...source.getPages()].sort(
+    (a, b) => rank(a.url) - rank(b.url),
+  );
+
+  const entries = await Promise.all(
+    pages.map(async (page) => {
+      const raw = await readFile(page.absolutePath, "utf-8");
+
+      return {
+        title: page.data.title ?? page.slugs.join("/"),
+        description: page.data.description,
+        url: page.url,
+        content: mdxToPlainMarkdown(raw),
+      };
+    }),
+  );
+
+  return entries;
+}

--- a/packages/docs/src/lib/metadata.ts
+++ b/packages/docs/src/lib/metadata.ts
@@ -1,0 +1,86 @@
+import type { Metadata } from "next";
+
+export const siteUrl = "https://mentis.alexdunlop.com";
+
+export const siteName = "mentis";
+
+export const siteTagline = "Accessible @mention autocomplete input for React";
+
+export const defaultTitle = `${siteName} | ${siteTagline}`;
+
+export const siteDescription =
+  "Accessible @mention autocomplete input for React. ContentEditable, zero dependencies, TypeScript-first — a modern react-mentions alternative.";
+
+/**
+ * Social card generated at build time by `src/app/opengraph-image.tsx`.
+ *
+ * Referenced explicitly rather than relying on file-convention inheritance,
+ * because declaring `openGraph` on a page replaces the inherited value.
+ */
+export const ogImage = {
+  url: "/opengraph-image",
+  width: 1200,
+  height: 630,
+  alt: `${siteName} — ${siteTagline}`,
+};
+
+/**
+ * Keywords used across the site. These mirror the npm package keywords so that
+ * search engines see consistent terminology in both places.
+ */
+export const siteKeywords = [
+  "react mentions",
+  "react mention input",
+  "mention input react",
+  "react-mentions alternative",
+  "@mention autocomplete",
+  "react autocomplete input",
+  "react combobox",
+  "react typeahead",
+  "react tagging input",
+  "contenteditable react",
+  "react mention chips",
+  "accessible react input",
+  "mentis",
+];
+
+/**
+ * Builds page metadata with canonical URL and social card filled in.
+ *
+ * @param path - Absolute site path, e.g. `/docs/installation`.
+ */
+export function createMetadata({
+  title,
+  description = siteDescription,
+  path = "/",
+}: {
+  title?: string;
+  description?: string;
+  path?: string;
+} = {}): Metadata {
+  const url = `${siteUrl}${path}`;
+  const socialTitle = title ? `${title} | ${siteName}` : defaultTitle;
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical: url,
+    },
+    openGraph: {
+      type: "website",
+      siteName,
+      locale: "en_US",
+      url,
+      title: socialTitle,
+      description,
+      images: [ogImage],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: socialTitle,
+      description,
+      images: [ogImage],
+    },
+  };
+}

--- a/packages/mentis/package.json
+++ b/packages/mentis/package.json
@@ -1,10 +1,10 @@
 {
   "name": "mentis",
   "version": "0.2.7",
-  "description": "A flexible mention tagger for React that hooks into your existing inputs.",
+  "description": "Accessible @mention autocomplete input for React. ContentEditable, zero dependencies, TypeScript-first — a modern react-mentions alternative.",
   "type": "module",
   "license": "MIT",
-  "homepage": "https://github.com/alexanderdunlop/mentis#readme",
+  "homepage": "https://mentis.alexdunlop.com",
   "bugs": {
     "url": "https://github.com/alexanderdunlop/mentis/issues"
   },
@@ -16,14 +16,34 @@
   "author": "Alexander Dunlop <alexjamesdunlop@gmail.com>",
   "funding": "https://github.com/sponsors/alexanderdunlop",
   "keywords": [
+    "react",
     "mentions",
-    "mentis",
-    "mention tagger",
     "mention",
-    "tag",
+    "mention-input",
+    "mentions-input",
+    "react-mentions",
+    "at-mention",
+    "autocomplete",
+    "combobox",
+    "typeahead",
+    "suggestions",
+    "tagging",
     "tagger",
-    "mention tag",
-    "react"
+    "chips",
+    "contenteditable",
+    "rich-text",
+    "text-editor",
+    "input",
+    "textarea",
+    "chat",
+    "comments",
+    "accessible",
+    "a11y",
+    "aria",
+    "typescript",
+    "zero-dependencies",
+    "react-component",
+    "mentis"
   ],
   "files": [
     "dist"


### PR DESCRIPTION
`react-mentions` hasn't shipped since 2022 and there's no obvious alternative. This makes `mentis` findable — both by developers searching for one, and by AI assistants asked to write a mention input.

## npm metadata (`packages/mentis/package.json`)

- Description now names the problem and the `react-mentions` gap instead of "a flexible mention tagger".
- Keywords rewritten around how people actually search: `mention-input`, `react-mentions`, `autocomplete`, `combobox`, `typeahead`, `tagging`, `contenteditable`, `a11y`, …
- `homepage` points at the docs site rather than the README anchor.

A patch changeset is included — npm only picks up new metadata on publish, so the keywords do nothing until a release goes out.

## README

- Leads with what the library does, plus a `mentis` vs `react-mentions` comparison table.
- Table of contents and an FAQ covering the questions search actually surfaces ("how do I add @mentions to a React app", "is it a drop-in replacement", "does it work with Next.js", …).
- A **For AI assistants and LLMs** section pointing at the machine-readable entry points.

## Docs site (`packages/docs`)

| Added | What it does |
| --- | --- |
| `src/lib/metadata.ts` | Shared helper — canonical URLs, title templates, OG/Twitter cards |
| `src/app/sitemap.ts` | `sitemap.xml`, previously missing entirely |
| `src/app/robots.ts` | `robots.txt`, previously missing entirely |
| `src/app/llms.txt/route.ts` | Index of every docs page, for AI crawlers |
| `src/app/llms-full.txt/route.ts` | Full docs as one 41KB plaintext file |
| `src/lib/llms.ts` | MDX → plain Markdown, emitted in sidebar order rather than alphabetically |
| `src/app/opengraph-image.tsx` | Generated 1200×630 social card |

Plus per-page canonicals and social cards on docs pages, JSON-LD (`WebSite` + `SoftwareSourceCode`) on the home page, and a unique meta description on all 13 pages — four had none and were inheriting the site default.

One subtlety worth knowing for future edits: the OG image is referenced explicitly through `ogImage` rather than relying on Next's file-convention inheritance, because declaring an `openGraph` block on a page *replaces* the inherited value instead of merging. Without that, `og:image` was silently absent from every page.

## Docs accuracy fixes

These were the real find — the docs documented an API that doesn't exist, which means any AI reading them generates broken code:

- `MentionData` is `displayValue` / `dataValue`. There is no plain `value` prop. (`llm.mdx`, README)
- The package is `mentis`, not `@mentis/react`. (`props.mdx`)
- `onChange` receives a `MentionData` object, not a string.

`llm.mdx` also gained a **Common Mistakes** section listing exactly these.

## Verification

- `pnpm build` — 7/7 tasks pass, all new routes prerender.
- `pnpm vitest run` in `packages/mentis` — 86 passed, 5 todo.
- Served the production build and confirmed against the real HTML: `og:image`, `og:title`, canonical, and JSON-LD present on the home page and docs pages; `robots.txt`, `sitemap.xml` (13 URLs), `llms.txt`, `llms-full.txt`, and `/opengraph-image` (200, `image/png`) all serve correctly.
- README FAQ and comparison-table claims checked against the source: `trigger`, `displayValue`, `dataValue`, `slotsProps` all exist; zero runtime dependencies; React 19 peer; `MentionInputProps`, `MentionOption`, `MentionData`, `SlotProps` all exported.

`@mentis/engine` typecheck/test fail locally for want of `node_modules` — pre-existing and untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)