### PR TITLE
feat(docs): add blog, and correct the react-mentions claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ It's built on `contentEditable` rather than a plain `<textarea>`, which is what 
 
 ## Why Mentis?
 
-[`react-mentions`](https://www.npmjs.com/package/react-mentions) has been the default choice for years, but it hasn't seen a release since 2022 and is built on a `<textarea>` + overlay approach that can't render true chips. Mentis is a maintained, modern alternative:
+[`react-mentions`](https://www.npmjs.com/package/react-mentions) has been the default choice for years, but its last release was 4.4.10 in June 2023, its GitHub repository now returns a 404, and it's built on a `<textarea>` + overlay approach that can't render true chips. Mentis is a maintained, modern alternative:
 
 |                              | Mentis                        | react-mentions          |
 | ---------------------------- | ----------------------------- | ----------------------- |
-| Last release                 | Actively maintained           | 2022                    |
+| Last release                 | Actively maintained           | June 2023               |
+| Issue tracker                | ✅ Open                       | ❌ Repository 404s      |
 | Foundation                   | `contentEditable`             | `<textarea>` + overlay  |
 | Mentions render as chips     | ✅ Real DOM elements          | ❌ Styled text overlay  |
 | Runtime dependencies         | ✅ Zero                       | `substyle`, others      |

--- a/packages/docs/content/blog/accessible-mention-autocomplete-aria-combobox.mdx
+++ b/packages/docs/content/blog/accessible-mention-autocomplete-aria-combobox.mdx
@@ -1,0 +1,247 @@
+---
+title: The ARIA combobox pattern for @mention autocomplete
+description: "A mention dropdown is a combobox, and most implementations get it wrong in the same three ways. The attributes you need, why focus must stay in the input, and how to test it."
+date: "2026-08-10"
+author: Alexander Dunlop
+order: 3
+summary: "An @mention autocomplete is an ARIA combobox with an attached listbox. Keyboard focus must never leave the input: put role=combobox on the editable element with aria-expanded, aria-controls, aria-autocomplete=list and aria-haspopup=listbox, put role=listbox on the dropdown with role=option on each row, and point aria-activedescendant at the id of the highlighted option so a screen reader announces it without moving focus. Use aria-selected only on the active option. The three common mistakes are moving DOM focus into the list, leaving aria-expanded static, and pointing aria-activedescendant at an id that does not exist."
+keywords:
+  - aria combobox pattern
+  - accessible autocomplete react
+  - aria-activedescendant
+  - accessible mention input
+  - combobox listbox aria
+  - screen reader autocomplete
+  - wai-aria combobox
+---
+
+Typing `@` and getting a filtered dropdown is a combobox. Not a menu, not a
+dialog, not a listbox on its own — a combobox with an attached popup. The WAI-ARIA
+Authoring Practices have a pattern for exactly this, and mention inputs get it
+wrong in a small number of very consistent ways.
+
+## The rule everything follows from
+
+**Keyboard focus never leaves the input.**
+
+This is the whole pattern in one line. The user is typing. If pressing the down
+arrow moves DOM focus into the list, they can no longer type, and every subsequent
+keystroke goes somewhere they did not intend. So the highlighted option is not
+focused — it is *referenced*, by id, from the input, using `aria-activedescendant`.
+Screen readers announce the referenced element as if it were focused. Focus itself
+never moves.
+
+Once you accept that, the attributes stop being arbitrary and start being a
+consequence.
+
+## The attributes
+
+On the editable element:
+
+| Attribute | Value | Why |
+| --- | --- | --- |
+| `role="combobox"` | static | Declares the input as a combobox |
+| `aria-expanded` | `true` / `false` | Whether the popup is currently open |
+| `aria-controls` | id of the listbox | Points at the popup it owns |
+| `aria-haspopup` | `"listbox"` | Says what kind of popup appears |
+| `aria-autocomplete` | `"list"` | Suggestions are listed, not inlined into the text |
+| `aria-activedescendant` | id of the highlighted option | The virtual focus |
+
+On the popup:
+
+| Attribute | Value | Why |
+| --- | --- | --- |
+| `role="listbox"` | static | The popup is a list of choices |
+| `id` | matches `aria-controls` | Completes the relationship |
+
+On each row:
+
+| Attribute | Value | Why |
+| --- | --- | --- |
+| `role="option"` | static | A selectable choice |
+| `id` | unique, referenced by `aria-activedescendant` | The target of virtual focus |
+| `aria-selected` | `true` on the active row only | Which one Enter will choose |
+
+Here is the whole thing as mentis renders it, with the dropdown open and the
+second option highlighted:
+
+```html
+<div class="mention-input-container">
+  <div
+    role="combobox"
+    contenteditable="true"
+    aria-autocomplete="list"
+    aria-haspopup="listbox"
+    aria-expanded="true"
+    aria-controls="mention-modal"
+    aria-activedescendant="mention-option-bob"
+  >Hey @b</div>
+
+  <div id="mention-modal" role="listbox">
+    <div id="mention-option-alice" role="option" aria-selected="false">Alice</div>
+    <div id="mention-option-bob"   role="option" aria-selected="true">Bob</div>
+  </div>
+</div>
+```
+
+Note that `aria-expanded` is `false` and `aria-activedescendant` and `aria-controls`
+are absent entirely when the dropdown is closed. That matters — see the mistakes below.
+
+## The three mistakes
+
+### 1. Moving DOM focus into the list
+
+The symptom is that arrow keys work but the user cannot keep typing to narrow the
+results, and Escape does something surprising. If you find yourself calling
+`.focus()` on an option, or managing `tabindex="-1"` across rows, you have built a
+menu rather than a combobox. Options in this pattern are never focusable and never
+in the tab order.
+
+### 2. Leaving `aria-expanded` hard-coded
+
+`aria-expanded="true"` written once in JSX and never updated is extremely common,
+because nothing looks wrong. A screen reader user is simply told the popup is open
+at all times, including when it is not, so they arrow into a list that is not there.
+It must be bound to the same state that decides whether the popup renders:
+
+```tsx
+aria-expanded={showModal}
+```
+
+### 3. Pointing `aria-activedescendant` at an id that does not exist
+
+If the list is empty, or the highlighted index is out of range, or the ids are
+generated with a different scheme than the one the attribute builds, the reference
+dangles. Screen readers announce nothing at all, so it presents as "the dropdown is
+silent" rather than as a broken attribute. Guard it:
+
+```tsx
+aria-activedescendant={
+  showModal && filteredOptions.length > 0
+    ? `mention-option-${filteredOptions[highlightedIndex].value}`
+    : undefined
+}
+```
+
+Returning `undefined` rather than an empty string matters — React omits the
+attribute entirely, which is the correct state, whereas `aria-activedescendant=""`
+is a dangling reference.
+
+## The keyboard contract
+
+| Key | Popup open | Popup closed |
+| --- | --- | --- |
+| <kbd>↓</kbd> / <kbd>↑</kbd> | Move the highlight | Normal caret movement |
+| <kbd>Enter</kbd> | Select the highlighted option | Newline / your `onKeyDown` |
+| <kbd>Tab</kbd> | Select the highlighted option | Move focus onward |
+| <kbd>Esc</kbd> | Close without selecting | — |
+| <kbd>←</kbd> / <kbd>→</kbd> | Caret movement, including into chips | Caret movement |
+
+Two things about that table are worth stating explicitly, because they are the
+questions people ask.
+
+**Escape must not clear the input.** It closes the popup and leaves the text alone.
+Clearing on Escape is a different pattern and it loses work.
+
+**Tab selecting the highlighted option is a deliberate choice.** The alternative —
+Tab moves focus out and abandons the selection — is also valid per the authoring
+practices. Selecting is the better behaviour for mentions specifically, because
+typing `@ali` and tabbing is a natural completion gesture. But it means Tab does
+not move focus while the popup is open, which you should be consistent about.
+
+In mentis, these keys are consumed internally while the popup is open, so your own
+`onKeyDown` is not called for them — deliberately, so that a form which submits on
+Enter does not submit when the user meant to pick a name.
+
+## The contentEditable wrinkle
+
+Putting `role="combobox"` on a `contenteditable` div rather than an `input` is
+legitimate and well supported, but it changes two things.
+
+First, the accessible value is the element's text content, which now includes chip
+elements. A mention rendered as `<span class="mention-chip">@Alice</span>` is
+announced as "@Alice" because that is its text — which is what you want, and is
+better than the overlay approach where a mention is an indistinguishable run of a
+longer string.
+
+Second, you need a placeholder. `contenteditable` has no `placeholder` attribute,
+so it is done with CSS on an empty element, which means it is *decoration* and not
+an accessible name. If the input has no visible `<label>`, give it one with
+`aria-label`:
+
+```tsx
+<MentionInput
+  options={users}
+  slotsProps={{
+    contentEditable: {
+      "aria-label": "Comment",
+      "data-placeholder": "Add a comment…",
+    },
+  }}
+/>
+```
+
+This is worth doing and is easy to forget — a combobox with no accessible name is
+announced as just "combobox".
+
+## Where mentis is currently short
+
+Being straight about it: mentis wires the combobox relationship, the listbox, the
+options, and `aria-activedescendant` correctly, and the keyboard contract above is
+implemented. What it does not yet do is announce *result counts* through a live
+region — there is no `aria-live` element saying "3 results available" when the
+filter changes. Sighted users see the list resize; screen reader users find out by
+arrowing through it. It is on the list.
+
+If that matters for your compliance target today, you can add it yourself around
+the component, since you control the `options` array and therefore know the count.
+
+## Testing it
+
+Automated tooling will not catch most of this. axe and Lighthouse check that
+attributes are well-formed, not that they are *true* — a hard-coded
+`aria-expanded="true"` passes every automated check ever written.
+
+The five-minute manual pass:
+
+1. Tab to the input. It should be announced with a name and as a combobox.
+2. Type the trigger. The popup opening should be announced.
+3. Arrow down. Each option should be announced as you land on it — **without** focus
+   leaving the input, which you can confirm by typing another letter and watching the
+   list filter.
+4. Press Escape. The popup closes, the text survives.
+5. Inspect the DOM with the popup closed and confirm `aria-expanded="false"` and no
+   `aria-activedescendant`.
+
+VoiceOver with Safari and NVDA with Firefox are the two combinations worth the time;
+they disagree often enough to be worth checking both.
+
+## FAQ
+
+### Should a mention dropdown use `role="menu"`?
+
+No. A menu is for commands, and its options are focusable. A mention dropdown offers
+values to insert into a field, which is `role="listbox"` inside a combobox.
+
+### Does `aria-selected` go on every option?
+
+Only on the currently highlighted one, set to `true`; the others should be `false`.
+In a single-select listbox, `aria-selected="true"` on several rows is contradictory.
+
+### Do I need `aria-owns` as well as `aria-controls`?
+
+No. `aria-controls` on the combobox pointing at the listbox id is the required
+relationship. `aria-owns` is only needed when the popup is not a DOM descendant *and*
+you need to fix the accessibility tree ordering — rendering the popup inside the same
+container, as mentis does, avoids the question.
+
+### Is `aria-autocomplete="list"` or `"both"` right?
+
+`"list"` when suggestions appear only in the popup. `"both"` when you also complete
+the text inline in the field. Mention inputs are almost always `"list"`.
+
+### What is the difference between `aria-activedescendant` and roving tabindex?
+
+Both track a virtual selection. `aria-activedescendant` keeps DOM focus in one place
+and points elsewhere; roving tabindex actually moves focus between elements. Comboboxes
+need the former, because the user has to keep typing.

--- a/packages/docs/content/blog/contenteditable-vs-textarea-mention-input.mdx
+++ b/packages/docs/content/blog/contenteditable-vs-textarea-mention-input.mdx
@@ -1,0 +1,174 @@
+---
+title: Why mention inputs outgrow the textarea
+description: "Most React mention libraries paint highlights on a div behind a transparent textarea. It is a clever trick with specific failure modes. Here is where it breaks, and what contentEditable costs you instead."
+date: "2026-08-10"
+author: Alexander Dunlop
+order: 2
+summary: "The textarea overlay technique renders a transparent textarea on top of a mirror div that repaints the same text with highlight spans behind it. It is popular because the browser keeps handling the caret, selection, and IME for you. It breaks when the mirror and the textarea disagree about text metrics — custom fonts, ligatures, RTL text, browser zoom, scroll position — and it can never produce a real chip, because a textarea can only contain text. contentEditable gives you real DOM chips and atomic deletion, at the cost of owning caret placement, paste sanitisation, undo, and IME composition yourself."
+keywords:
+  - contenteditable vs textarea
+  - react mention input architecture
+  - textarea overlay highlight
+  - contenteditable react
+  - mention chips react
+  - rich text input react
+---
+
+Nearly every mention input for React is built one of two ways. The choice is
+invisible from the outside until the day it isn't, and then it explains every bug
+you have.
+
+## The overlay trick
+
+Put a `textarea` on top. Make its text transparent but keep the caret visible.
+Behind it, absolutely position a `div` that renders the *same string*, character
+for character, except the mentions are wrapped in coloured spans. Sync the scroll
+positions. The user sees the highlights on the div and types into the textarea.
+
+It is genuinely clever, and the reason it is everywhere is that you get an
+enormous amount for free. The browser handles caret placement, click-to-position,
+double-click word selection, shift-arrow selection, drag selection, IME
+composition for Japanese and Chinese input, native undo, spellcheck, and mobile
+autocorrect. You write none of that. `react-mentions` works this way, and it
+worked well enough to reach 691,000 weekly downloads.
+
+The whole technique rests on one assumption: **the mirror div lays out text
+identically to the textarea.** Everything that goes wrong, goes wrong there.
+
+## Where the mirror drifts
+
+The two elements are different tag types with different default user-agent
+styling, and you are asking them to agree on glyph positions to the pixel.
+
+- **Font loading.** The mirror renders with the fallback font for the first paint;
+  the webfont arrives and the metrics shift. Highlights land a few pixels off until
+  something forces a reflow.
+- **Ligatures and kerning.** A `textarea` and a `div` do not always apply the same
+  font features. `fi`, `ffl`, and kerning pairs across a highlight boundary can
+  measure differently.
+- **Browser zoom and fractional device pixels.** Subpixel rounding accumulates
+  across a long line. At 110% zoom the offset is visible; at 175% it is obvious.
+- **Scroll sync.** The mirror is synced on the textarea's scroll event, so it is
+  always one frame behind on fast scroll or momentum scroll on iOS.
+- **RTL and bidirectional text.** Mixed Arabic or Hebrew and Latin text reorders
+  visually. Getting a highlight to land on the right run in both elements
+  simultaneously is genuinely hard.
+- **Wrapping.** `white-space`, `word-break`, `overflow-wrap`, and the scrollbar's
+  own width all have to match exactly, or the mirror wraps one word earlier than
+  the textarea and every line below is wrong.
+
+Each of these is fixable. That is the trap — they are all *individually* fixable,
+so the architecture never looks wrong, it just accumulates a long tail of
+per-browser corrections.
+
+## The thing you cannot fix
+
+A `textarea` contains text. Only text. No elements, ever.
+
+So a "chip" in the overlay approach is a coloured background painted on a div
+*behind* a transparent character range. It looks like a chip. It is not one, and
+the difference shows up wherever behaviour, rather than appearance, is involved:
+
+- **Deletion is per-character.** Backspace at the end of `@Alexander` removes the
+  `r`, leaving `@Alexande` — still highlighted, now referring to nobody. Libraries
+  work around this by intercepting backspace and deleting the whole run, which
+  works until the caret gets there by click or by selection rather than by arrow key.
+- **Selection can split a mention.** Drag from the middle of a mention to the middle
+  of a word. Copy. You now have half an entity on the clipboard, and the markup
+  string that comes back is unparseable.
+- **The chip cannot be a component.** No avatar, no hover card, no per-chip
+  affordance, no border-radius that survives a line wrap — it is a background
+  colour on a text range.
+- **Screen readers see a flat string.** There is no element boundary to announce,
+  so a mention is read as ordinary text.
+
+## What contentEditable gives you
+
+Make the input a `contentEditable` div and a mention becomes an actual element in
+the DOM. In mentis, that is a `span` carrying its own data:
+
+```html
+<div class="content-editable-input" role="combobox" contenteditable="true">
+  Hey <span class="mention-chip" data-value="alice" data-label="Alice">@Alice</span>, take a look
+</div>
+```
+
+Now the chip is a real node. It can be styled with a border, a background, and a
+radius that behaves properly across a line break. Backspace against it deletes the
+whole node rather than a character. Selection APIs treat it as a unit. Serialising
+is a DOM walk instead of a regex over markup, which is why mentis can hand you
+`displayValue` and `dataValue` as two separate strings without asking you to parse
+`@[__display__](__id__)` yourself.
+
+There is no mirror, so there is nothing to drift.
+
+## What it costs
+
+This is not a free upgrade, and anyone who tells you otherwise has not shipped one.
+The moment you set `contenteditable`, you inherit a pile of problems the textarea
+was solving silently:
+
+- **Caret placement.** You now position the caret yourself after every programmatic
+  change — inserting a chip, replacing a range, restoring after a re-render. Range
+  and Selection are fiddly, and the browsers disagree at the edges.
+- **Paste.** The default is to paste *HTML*. Someone pastes from Word and you have
+  `<o:p>` tags in your input. You must intercept paste and sanitise it down to text
+  and your own chips.
+- **Undo.** Native undo in a contentEditable is unreliable once you have made
+  programmatic DOM changes, so you generally end up implementing an undo stack.
+- **IME composition.** Japanese, Chinese, and Korean input arrives as a
+  multi-keystroke composition. If you read the DOM mid-composition, you corrupt it.
+  `compositionstart` and `compositionend` become load-bearing.
+- **Grapheme clusters.** "One character" is not one code unit. `👩‍👩‍👧‍👦` is seven code
+  points; a flag is two; `é` may be one or two. Naive index arithmetic cuts emoji in
+  half.
+- **React and the DOM disagree.** React wants to own the DOM; contentEditable means
+  the *browser* mutates it on every keystroke. You end up reconciling by hand.
+
+None of these are exotic. They are the standard cost of the approach, and they are
+why the overlay trick remains popular.
+
+## Which should you use?
+
+| Use the textarea overlay when | Use contentEditable when |
+| --- | --- |
+| Mentions are decoration — colour on a word | Mentions are entities users manipulate |
+| Your text is single-script and left-to-right | You ship RTL, CJK, or mixed-script content |
+| You need native undo and spellcheck, cheaply | You need chips to delete and select atomically |
+| Plain-text storage is the requirement | You want display text and IDs separated |
+| You are adding this in an afternoon | You want per-chip UI later — avatars, hovercards |
+
+There is no universally correct answer. There is a correct answer *for a given
+product*, and it is worth knowing which one you picked and why, rather than
+discovering it from a bug report about Arabic text at 125% zoom.
+
+mentis takes the contentEditable side of this — see
+[chips](/docs/chips) for how mention nodes behave, or
+[migrating from react-mentions](/blog/migrate-from-react-mentions) if you are
+coming from the other approach.
+
+## FAQ
+
+### Why do React mention libraries use a transparent textarea?
+
+Because a `textarea` cannot contain elements, so highlights have to be painted on a
+separate element behind it. Keeping the real textarea on top preserves native caret,
+selection, IME, and undo behaviour for free.
+
+### Can you put a styled chip inside a textarea?
+
+No. A `textarea` holds text only. Anything that looks like a chip inside one is
+drawn on a different element positioned behind the text.
+
+### Is contentEditable bad for accessibility?
+
+Not inherently. A `contentEditable` div with `role="combobox"` and correct
+`aria-activedescendant` wiring is a well-supported pattern, and real chip elements
+give screen readers a boundary that a highlighted text range does not. See
+[the ARIA combobox pattern for mention inputs](/blog/accessible-mention-autocomplete-aria-combobox).
+
+### Does contentEditable work on mobile?
+
+Yes, though it is where the cost is highest — mobile keyboards, autocorrect, and IME
+interact with programmatic DOM changes in ways desktop browsers do not. Test on real
+devices rather than a narrow viewport.

--- a/packages/docs/content/blog/migrate-from-react-mentions.mdx
+++ b/packages/docs/content/blog/migrate-from-react-mentions.mdx
@@ -1,0 +1,259 @@
+---
+title: How to migrate from react-mentions to mentis
+description: "react-mentions still has 691k weekly downloads, but its GitHub repo is gone and the last release was June 2023. Here is a prop-by-prop migration to mentis — and when a fork is the better call."
+date: "2026-08-10"
+author: Alexander Dunlop
+order: 1
+summary: "react-mentions is unmaintained: its last release was 4.4.10 on 30 June 2023 and github.com/signavio/react-mentions now returns 404. To migrate to mentis, replace the MentionsInput/Mention children API with a single MentionInput and an options array, swap the value prop for displayValue, and read mentionData.dataValue instead of parsing @[__display__](__id__) markup yourself. If you need async suggestion loading, custom suggestion rendering, or multiple triggers in one input, mentis does not support those yet — use react-mentions-ts instead."
+keywords:
+  - react-mentions alternative
+  - migrate react-mentions
+  - react-mentions unmaintained
+  - react-mentions replacement
+  - react mention input
+  - react-mentions typescript
+  - mentions input react 19
+---
+
+If you are reading this, you probably ran `npm audit`, or bumped React, or clicked
+through to `react-mentions`' GitHub link and got a 404. Here is where things
+actually stand, and what to do about it.
+
+## Is react-mentions dead?
+
+Effectively, yes — though "dead" undersells how many people are still on it.
+
+| | Status |
+| --- | --- |
+| Latest release | `4.4.10`, published **30 June 2023** |
+| GitHub repository | `github.com/signavio/react-mentions` → **404** |
+| Weekly npm downloads | **~691,000** |
+| Issue tracker | Gone with the repository |
+
+That combination is the problem. The package still works — 691k weekly downloads
+is not a rounding error — but there is nowhere to report a bug, nowhere to ask a
+question, and no one to merge a fix. Every React major, every transitive
+dependency advisory, every new bundler default is now something you absorb
+yourself.
+
+## What are the actual options?
+
+Be honest with yourself about which of these you are: not everyone should
+migrate, and not everyone who migrates should pick mentis.
+
+| Option | Best when | Cost |
+| --- | --- | --- |
+| **Stay on react-mentions** | It works, you are not upgrading anything, you can vendor a patch if needed | Unbounded — no upstream, no tracker |
+| **[react-mentions-ts](https://www.npmjs.com/package/react-mentions-ts)** | You want out of the maintenance risk with the smallest possible diff | Near-zero — it is a maintained fork of the same API |
+| **[rc-mentions](https://www.npmjs.com/package/rc-mentions)** | You are already on Ant Design | Ties you to the antd ecosystem |
+| **mentis** | You want real DOM chips, ARIA combobox semantics, and no markup parsing | A genuine API change — this post |
+
+If your goal is purely "stop depending on an abandoned package", **react-mentions-ts
+is the rational choice** and you should stop reading here. It is a drop-in fork; the
+migration is a string change in `package.json`. Picking mentis only makes sense if
+you want what the different architecture buys you, covered in
+[why mention inputs outgrow the textarea](/blog/contenteditable-vs-textarea-mention-input).
+
+## What mentis does not do yet
+
+Stated up front, because finding out three files into a migration is worse.
+
+- **No async suggestion loading.** react-mentions lets you pass `data` a function
+  `(query, callback) => void` to fetch suggestions per keystroke. `mentis` takes a
+  static `options` array; you filter and fetch in your own component and pass the
+  result down.
+- **No custom suggestion rendering.** There is no equivalent of `renderSuggestion`.
+  You can restyle each option through `slotsProps.option`, but you cannot render
+  arbitrary JSX (avatar + name + handle) inside a row.
+- **One trigger per input.** react-mentions supports multiple `<Mention>` children
+  with different triggers in a single field. `mentis` takes a single `trigger` string.
+- **No `singleLine` mode.** The input is always multi-line.
+
+If any of those are load-bearing for you, migrating will be painful. That is the
+honest answer.
+
+## The prop mapping
+
+| react-mentions | mentis | Notes |
+| --- | --- | --- |
+| `<MentionsInput>` + `<Mention>` children | `<MentionInput>`, no children | Configuration moves to props |
+| `value` | `displayValue` | There is **no** `value` prop on mentis |
+| `onChange(event, newValue, newPlainTextValue, mentions)` | `onChange(mentionData)` | One object argument, not four positional ones |
+| `newValue` (markup string) | `mentionData.dataValue` | Already resolved — no markup to parse |
+| `newPlainTextValue` | `mentionData.displayValue` | What the user sees |
+| `mentions` | `mentionData.mentions` | `{ label, value, startIndex, endIndex }[]` |
+| `<Mention data={users} />` | `options={users}` | `{ label, value }[]` |
+| `<Mention trigger="@" />` | `trigger="@"` | Default is `"@"` |
+| `markup="@[__display__](__id__)"` | — | No markup format; `dataValue` carries the IDs |
+| `displayTransform` | — | Set `label` to what you want displayed |
+| `appendSpaceOnAdd` | Always on | A space is inserted after a chip |
+| `style` (substyle object) | `slotsProps` (class names) | See below |
+| `className` / `classNames` | `slotsProps.container.className` etc. | |
+| `onKeyDown` | `onKeyDown` | Same idea; see the caveat below |
+| `a11ySuggestionsListLabel` | — | The listbox is wired via `aria-controls`/`aria-activedescendant` |
+
+## Before and after
+
+The canonical react-mentions setup:
+
+```tsx
+import { MentionsInput, Mention } from "react-mentions";
+
+const users = [
+  { id: "alice", display: "Alice" },
+  { id: "bob", display: "Bob" },
+];
+
+function CommentBox() {
+  const [value, setValue] = useState("");
+
+  return (
+    <MentionsInput
+      value={value}
+      onChange={(event, newValue, newPlainTextValue, mentions) => {
+        setValue(newValue);
+      }}
+    >
+      <Mention trigger="@" data={users} markup="@[__display__](__id__)" />
+    </MentionsInput>
+  );
+}
+```
+
+The same thing in mentis:
+
+```tsx
+"use client";
+
+import { useState } from "react";
+import { MentionInput, type MentionData } from "mentis";
+import "mentis/dist/index.css";
+
+const users = [
+  { label: "Alice", value: "alice" },
+  { label: "Bob", value: "bob" },
+];
+
+function CommentBox() {
+  const [displayValue, setDisplayValue] = useState("");
+  const [dataValue, setDataValue] = useState("");
+
+  return (
+    <MentionInput
+      displayValue={displayValue}
+      options={users}
+      trigger="@"
+      onChange={(mentionData: MentionData) => {
+        setDisplayValue(mentionData.displayValue);
+        setDataValue(mentionData.dataValue);
+      }}
+    />
+  );
+}
+```
+
+Three things changed structurally: `id`/`display` became `value`/`label`, the
+`<Mention>` child became props, and you now hold two strings instead of one
+markup string.
+
+## Migrating your stored data
+
+This is the part that takes real time, and it is worth doing deliberately.
+
+react-mentions persists a **markup string** — `"Hey @[Alice](alice), look at this"`.
+mentis persists `dataValue`, which contains the raw IDs and no display labels.
+The two are not the same shape, so you need a one-off conversion:
+
+```ts
+/** `"Hey @[Alice](alice)"` → `"Hey @alice"` */
+export function markupToDataValue(markup: string): string {
+  return markup.replace(/@\[[^\]]*\]\(([^)]*)\)/g, "@$1");
+}
+```
+
+Run that over your existing rows in a migration, or lazily on read behind a
+`schemaVersion` column if you cannot take the write. Keep the original column
+until you are confident — this is exactly the kind of transform where one
+unescaped bracket in user content ruins a Saturday.
+
+To render a stored value back into chips, pass it as the `dataValue` prop and
+mentis reconstructs the chips from your `options`:
+
+```tsx
+<MentionInput dataValue={storedValue} options={users} onChange={handleChange} />
+```
+
+## Migrating your styles
+
+react-mentions styles through `substyle`, so you hand it a nested style object.
+mentis has no style prop at all — every part takes a class name, so Tailwind,
+CSS modules, and plain CSS all work the same way:
+
+```tsx
+<MentionInput
+  options={users}
+  slotsProps={{
+    container: { className: "relative w-full" },
+    contentEditable: {
+      className: "min-h-24 rounded-lg border p-3",
+      "data-placeholder": "Add a comment…",
+    },
+    modal: { className: "rounded-lg border bg-white shadow-lg" },
+    option: { className: "px-3 py-2 cursor-pointer" },
+    highlightedClassName: "bg-blue-50",
+    chipClassName: "rounded bg-blue-100 px-1 text-blue-800",
+  }}
+/>
+```
+
+The full slot list is in the [styling docs](/docs/styling).
+
+## Gotchas that will cost you an hour each
+
+1. **There is no `value` prop.** The controlled props are `displayValue` and
+   `dataValue`. Passing `value` silently does nothing — the input just looks
+   uncontrolled.
+2. **`onChange` receives an object, not a string.** `onChange={setDisplayValue}`
+   will store `[object Object]`.
+3. **Import the stylesheet.** `import "mentis/dist/index.css"` — without it the
+   chips and dropdown render unstyled and it looks broken rather than plain.
+4. **It is a client component.** Under the Next.js App Router, the importing file
+   needs `"use client"`.
+5. **Your `onKeyDown` is bypassed while the dropdown is open.** Enter, Tab, Escape
+   and the arrow keys are consumed for navigation. If you submit a form on Enter,
+   that is the behaviour you want — but test it with the menu open.
+
+## FAQ
+
+### Is react-mentions still safe to use in 2026?
+
+It still functions, and 691k weekly downloads suggests most people are still on it.
+The risk is not that it breaks tomorrow; it is that when it does break — a React
+major, a bundler change, a security advisory in a transitive dependency — there is
+no repository to file against and no maintainer to merge a fix.
+
+### What is the closest drop-in replacement for react-mentions?
+
+[`react-mentions-ts`](https://www.npmjs.com/package/react-mentions-ts), a maintained
+TypeScript fork of the same API. mentis is a different API and a different
+architecture, so it is a migration rather than a swap.
+
+### Does mentis support React 19?
+
+Yes. The peer range is `>=18.2.0 || ^19.0.0-0`.
+
+### Can I load mention suggestions from an API?
+
+Not from inside the component — there is no async `data` callback. Fetch in your own
+component, hold the results in state, and pass them as `options`.
+
+### How do I store mentions in a database after migrating?
+
+Store `mentionData.dataValue`, which contains option IDs rather than display labels,
+so renaming a user does not rewrite history. Pass it back as `dataValue` to rehydrate.
+See [onChange](/docs/onchange).
+
+### Does mentis need `@types/mentis`?
+
+No. Types ship in the package — `MentionInputProps`, `MentionOption`, `MentionData`,
+and `SlotProps` are all exported.

--- a/packages/docs/content/docs/llm.mdx
+++ b/packages/docs/content/docs/llm.mdx
@@ -20,7 +20,7 @@ import { MentionInput } from "mentis";
 import "mentis/dist/index.css";
 ```
 
-It is commonly reached for as a maintained alternative to `react-mentions`, which was last released in 2022 and is built on a `<textarea>` overlay rather than `contentEditable`.
+It is commonly reached for as a maintained alternative to `react-mentions`, whose last release was 4.4.10 in June 2023 and whose GitHub repository is no longer reachable. `react-mentions` is built on a `<textarea>` overlay rather than `contentEditable`.
 
 ## Core Architecture
 

--- a/packages/docs/package.json
+++ b/packages/docs/package.json
@@ -30,6 +30,7 @@
     "postcss": "^8.5.6",
     "shiki": "^3.8.1",
     "tailwindcss": "^4.1.11",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "zod": "3.25.76"
   }
 }

--- a/packages/docs/source.config.ts
+++ b/packages/docs/source.config.ts
@@ -1,9 +1,11 @@
 import {
+  defineCollections,
   defineConfig,
   defineDocs,
   frontmatterSchema,
   metaSchema,
 } from "fumadocs-mdx/config";
+import { z } from "zod";
 
 // You can customise Zod schemas for frontmatter and `meta.json` here
 // see https://fumadocs.vercel.app/docs/mdx/collections#define-docs
@@ -14,6 +16,43 @@ export const docs = defineDocs({
   meta: {
     schema: metaSchema,
   },
+});
+
+/**
+ * Long-form articles, kept separate from the reference docs.
+ *
+ * `description` is required here (unlike in `docs`) because it is the meta
+ * description, the social card copy, and the summary a model sees in
+ * `llms.txt` — a post without one is invisible in all three.
+ */
+export const blog = defineCollections({
+  type: "doc",
+  dir: "content/blog",
+  schema: frontmatterSchema.extend({
+    description: z.string(),
+    /** Publication date, `YYYY-MM-DD`. Drives ordering and `datePublished`. */
+    date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    /** Last substantive revision, `YYYY-MM-DD`. Omit until the post changes. */
+    updated: z
+      .string()
+      .regex(/^\d{4}-\d{2}-\d{2}$/)
+      .optional(),
+    author: z.string().default("Alexander Dunlop"),
+    /**
+     * Tie-break for posts sharing a `date`, lowest first. Without it, same-day
+     * posts fall back to filename order, which is not a reading order.
+     */
+    order: z.number().default(0),
+    /** Article-level keywords, merged with the site-wide set. */
+    keywords: z.array(z.string()).default([]),
+    /**
+     * A direct, self-contained answer to the question in the title.
+     *
+     * Rendered at the top of the post and lifted verbatim into `llms.txt`, so
+     * a model that reads nothing else still gets the correct answer.
+     */
+    summary: z.string(),
+  }),
 });
 
 export default defineConfig({

--- a/packages/docs/src/app/blog/[slug]/page.tsx
+++ b/packages/docs/src/app/blog/[slug]/page.tsx
@@ -1,0 +1,137 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { blog } from "@/lib/source";
+import { getMDXComponents } from "@/mdx-components";
+import { formatDate, getFaqEntries } from "@/lib/blog";
+import { author, createArticleMetadata, ogImage, siteUrl } from "@/lib/metadata";
+
+export async function generateStaticParams() {
+  return blog.getPages().map((page) => ({ slug: page.slugs[0] }));
+}
+
+export async function generateMetadata(props: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await props.params;
+  const page = blog.getPage([slug]);
+  if (!page) notFound();
+
+  return createArticleMetadata({
+    title: page.data.title,
+    description: page.data.description,
+    path: page.url,
+    date: page.data.date,
+    updated: page.data.updated,
+    keywords: page.data.keywords,
+  });
+}
+
+export default async function BlogPost(props: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await props.params;
+  const page = blog.getPage([slug]);
+  if (!page) notFound();
+
+  const MDXContent = page.data.body;
+  const faq = await getFaqEntries(page.absolutePath);
+  const url = `${siteUrl}${page.url}`;
+
+  /**
+   * `TechArticle` rather than plain `BlogPosting` — these are developer
+   * documentation in substance, and the FAQ is emitted as a linked `FAQPage`
+   * so the question/answer pairs are eligible for rich results on their own.
+   */
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@graph": [
+      {
+        "@type": "TechArticle",
+        "@id": `${url}#article`,
+        headline: page.data.title,
+        description: page.data.description,
+        abstract: page.data.summary,
+        datePublished: page.data.date,
+        dateModified: page.data.updated ?? page.data.date,
+        inLanguage: "en",
+        keywords: page.data.keywords.join(", "),
+        image: `${siteUrl}${ogImage.url}`,
+        author: { "@type": "Person", ...author },
+        publisher: { "@type": "Person", ...author },
+        isPartOf: { "@id": `${siteUrl}/blog#blog` },
+        about: { "@id": `${siteUrl}/#software` },
+        mainEntityOfPage: { "@type": "WebPage", "@id": url },
+      },
+      ...(faq.length > 0
+        ? [
+            {
+              "@type": "FAQPage",
+              "@id": `${url}#faq`,
+              isPartOf: { "@id": `${url}#article` },
+              mainEntity: faq.map((entry) => ({
+                "@type": "Question",
+                name: entry.question,
+                acceptedAnswer: { "@type": "Answer", text: entry.answer },
+              })),
+            },
+          ]
+        : []),
+    ],
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-16">
+      <script
+        type="application/ld+json"
+        // Static, author-controlled JSON — no user input is interpolated.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <article>
+        <header>
+          <h1 className="text-4xl font-bold tracking-tight">
+            {page.data.title}
+          </h1>
+          <p className="mt-4 text-lg text-fd-muted-foreground">
+            {page.data.description}
+          </p>
+          <p className="mt-4 text-sm text-fd-muted-foreground">
+            <span>{page.data.author}</span>
+            {" · "}
+            <time dateTime={page.data.date}>{formatDate(page.data.date)}</time>
+            {page.data.updated ? (
+              <>
+                {" · updated "}
+                <time dateTime={page.data.updated}>
+                  {formatDate(page.data.updated)}
+                </time>
+              </>
+            ) : null}
+          </p>
+        </header>
+
+        {/*
+          The summary answers the title's question outright, before the article
+          argues it. Search snippets and models both tend to lift the first
+          self-contained answer they find.
+        */}
+        <div className="mt-8 rounded-lg border border-fd-border bg-fd-card p-5">
+          <p className="text-sm font-semibold uppercase tracking-wide text-fd-muted-foreground">
+            In short
+          </p>
+          <p className="mt-2">{page.data.summary}</p>
+        </div>
+
+        <div className="prose mt-10">
+          <MDXContent components={getMDXComponents()} />
+        </div>
+      </article>
+
+      <footer className="mt-16 border-t border-fd-border pt-8">
+        <Link href="/blog" className="text-sm hover:underline">
+          ← All posts
+        </Link>
+      </footer>
+    </main>
+  );
+}

--- a/packages/docs/src/app/blog/layout.tsx
+++ b/packages/docs/src/app/blog/layout.tsx
@@ -7,14 +7,8 @@ export default function Layout({ children }: { children: ReactNode }) {
     <HomeLayout
       {...baseOptions}
       links={[
-        {
-          text: "Documentation",
-          url: "/docs",
-        },
-        {
-          text: "Blog",
-          url: "/blog",
-        },
+        { text: "Documentation", url: "/docs" },
+        { text: "Blog", url: "/blog", active: "nested-url" },
       ]}
     >
       {children}

--- a/packages/docs/src/app/blog/page.tsx
+++ b/packages/docs/src/app/blog/page.tsx
@@ -1,0 +1,73 @@
+import Link from "next/link";
+import { getBlogPosts } from "@/lib/source";
+import { formatDate } from "@/lib/blog";
+import { createMetadata, siteUrl } from "@/lib/metadata";
+
+const title = "Blog";
+const description =
+  "Articles on building @mention inputs in React — migrating off react-mentions, contentEditable architecture, and the ARIA combobox pattern.";
+
+export const metadata = createMetadata({ title, description, path: "/blog" });
+
+export default function BlogIndex() {
+  const posts = getBlogPosts();
+
+  /**
+   * A `Blog` node with its posts listed, so a crawler can enumerate the archive
+   * from the index alone rather than following every link.
+   */
+  const structuredData = {
+    "@context": "https://schema.org",
+    "@type": "Blog",
+    "@id": `${siteUrl}/blog#blog`,
+    name: `${title} | mentis`,
+    description,
+    url: `${siteUrl}/blog`,
+    inLanguage: "en",
+    blogPost: posts.map((post) => ({
+      "@type": "BlogPosting",
+      "@id": `${siteUrl}${post.url}#article`,
+      headline: post.data.title,
+      description: post.data.description,
+      datePublished: post.data.date,
+      dateModified: post.data.updated ?? post.data.date,
+      url: `${siteUrl}${post.url}`,
+    })),
+  };
+
+  return (
+    <main className="mx-auto w-full max-w-3xl px-4 py-16">
+      <script
+        type="application/ld+json"
+        // Static, author-controlled JSON — no user input is interpolated.
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+      />
+
+      <h1 className="text-4xl font-bold tracking-tight">{title}</h1>
+      <p className="mt-4 text-fd-muted-foreground">{description}</p>
+
+      <ul className="mt-12 flex flex-col gap-10">
+        {posts.map((post) => (
+          <li key={post.url}>
+            <article>
+              <Link href={post.url} className="group block">
+                <h2 className="text-2xl font-semibold tracking-tight group-hover:underline">
+                  {post.data.title}
+                </h2>
+                <p className="mt-2 text-fd-muted-foreground">
+                  {post.data.description}
+                </p>
+              </Link>
+              <time
+                dateTime={post.data.date}
+                className="mt-3 block text-sm text-fd-muted-foreground"
+              >
+                {formatDate(post.data.date)}
+              </time>
+            </article>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/packages/docs/src/app/layout.tsx
+++ b/packages/docs/src/app/layout.tsx
@@ -59,6 +59,12 @@ export default function Layout({ children }: { children: ReactNode }) {
       <head>
         <link rel="preload" as="image" href="/logo/logo.png" />
         <link rel="icon" href="/logo/logo.png" />
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="mentis — blog"
+          href="/rss.xml"
+        />
       </head>
       <body className="flex flex-col min-h-screen">
         <RootProvider>{children}</RootProvider>

--- a/packages/docs/src/app/llms-full.txt/route.ts
+++ b/packages/docs/src/app/llms-full.txt/route.ts
@@ -1,4 +1,4 @@
-import { getDocEntries } from "@/lib/llms";
+import { getBlogEntries, getDocEntries } from "@/lib/llms";
 import { siteDescription, siteUrl } from "@/lib/metadata";
 
 export const dynamic = "force-static";
@@ -11,9 +11,9 @@ export const revalidate = false;
  * @see https://llmstxt.org
  */
 export async function GET() {
-  const entries = await getDocEntries();
+  const [docs, posts] = await Promise.all([getDocEntries(), getBlogEntries()]);
 
-  const sections = entries
+  const sections = [...docs, ...posts]
     .map((entry) => {
       const header = [
         `# ${entry.title}`,

--- a/packages/docs/src/app/llms.txt/route.ts
+++ b/packages/docs/src/app/llms.txt/route.ts
@@ -1,4 +1,4 @@
-import { getDocEntries } from "@/lib/llms";
+import { getBlogEntries, getDocEntries } from "@/lib/llms";
 import { siteDescription, siteUrl } from "@/lib/metadata";
 
 export const dynamic = "force-static";
@@ -10,14 +10,16 @@ export const revalidate = false;
  * @see https://llmstxt.org
  */
 export async function GET() {
-  const entries = await getDocEntries();
+  const [entries, posts] = await Promise.all([
+    getDocEntries(),
+    getBlogEntries(),
+  ]);
 
-  const links = entries
-    .map(
-      (entry) =>
-        `- [${entry.title}](${siteUrl}${entry.url})${entry.description ? `: ${entry.description}` : ""}`,
-    )
-    .join("\n");
+  const toLink = (entry: { title: string; url: string; description?: string }) =>
+    `- [${entry.title}](${siteUrl}${entry.url})${entry.description ? `: ${entry.description}` : ""}`;
+
+  const links = entries.map(toLink).join("\n");
+  const postLinks = posts.map(toLink).join("\n");
 
   const body = `# mentis
 
@@ -40,6 +42,10 @@ The controlled props are \`displayValue\` (what the user sees) and \`dataValue\`
 ## Documentation
 
 ${links}
+
+## Articles
+
+${postLinks}
 
 ## Optional
 

--- a/packages/docs/src/app/rss.xml/route.ts
+++ b/packages/docs/src/app/rss.xml/route.ts
@@ -1,0 +1,62 @@
+import { getBlogPosts } from "@/lib/source";
+import { author, siteName, siteUrl } from "@/lib/metadata";
+
+export const dynamic = "force-static";
+export const revalidate = false;
+
+const feedDescription =
+  "Articles on building @mention inputs in React — migrating off react-mentions, contentEditable architecture, and the ARIA combobox pattern.";
+
+/** Escapes the five XML predefined entities. */
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/** RSS requires RFC 822 dates, not the ISO dates the frontmatter carries. */
+function toRfc822(date: string): string {
+  return new Date(`${date}T00:00:00Z`).toUTCString();
+}
+
+export async function GET() {
+  const posts = getBlogPosts();
+
+  const items = posts
+    .map((post) => {
+      const url = `${siteUrl}${post.url}`;
+
+      return `    <item>
+      <title>${escapeXml(post.data.title)}</title>
+      <link>${url}</link>
+      <guid isPermaLink="true">${url}</guid>
+      <description>${escapeXml(post.data.description)}</description>
+      <pubDate>${toRfc822(post.data.date)}</pubDate>
+      <author>${escapeXml(post.data.author)}</author>
+    </item>`;
+    })
+    .join("\n");
+
+  const body = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>${siteName} — blog</title>
+    <link>${siteUrl}/blog</link>
+    <description>${escapeXml(feedDescription)}</description>
+    <language>en</language>
+    <managingEditor>${escapeXml(author.name)}</managingEditor>
+    <atom:link href="${siteUrl}/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>
+`;
+
+  return new Response(body, {
+    headers: {
+      "Content-Type": "application/rss+xml; charset=utf-8",
+    },
+  });
+}

--- a/packages/docs/src/app/sitemap.ts
+++ b/packages/docs/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import { source } from "@/lib/source";
+import { getBlogPosts, source } from "@/lib/source";
 import { siteUrl } from "@/lib/metadata";
 
 export const dynamic = "force-static";
@@ -11,12 +11,27 @@ export default function sitemap(): MetadataRoute.Sitemap {
     priority: 0.8,
   }));
 
+  const posts = getBlogPosts().map((post) => ({
+    url: `${siteUrl}${post.url}`,
+    // Articles are revised rarely, and `lastModified` is only meaningful if it
+    // is true — a date that always moves teaches crawlers to ignore it.
+    lastModified: post.data.updated ?? post.data.date,
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
   return [
     {
       url: siteUrl,
       changeFrequency: "weekly",
       priority: 1,
     },
+    {
+      url: `${siteUrl}/blog`,
+      changeFrequency: "weekly",
+      priority: 0.6,
+    },
     ...docs,
+    ...posts,
   ];
 }

--- a/packages/docs/src/lib/blog.ts
+++ b/packages/docs/src/lib/blog.ts
@@ -1,0 +1,86 @@
+import { readFile } from "node:fs/promises";
+
+export interface FaqEntry {
+  question: string;
+  answer: string;
+}
+
+/**
+ * Reduces inline Markdown to the plain prose underneath it.
+ *
+ * Structured data and `llms.txt` both want the sentence, not the syntax — a
+ * `FAQPage` answer containing raw `[text](url)` is a Search Console warning.
+ */
+function toPlainText(markdown: string): string {
+  return markdown
+    .replace(/\[([^\]]+)\]\([^)]*\)/g, "$1") // links → their text
+    .replace(/<kbd>|<\/kbd>/g, "")
+    .replace(/[*_`]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * Pulls the `### question` / answer pairs out of a post's `## FAQ` section.
+ *
+ * Reading the source rather than the rendered output keeps this independent of
+ * MDX compilation, at the cost of only understanding the heading convention the
+ * posts actually use. Posts without an FAQ section yield an empty list.
+ */
+export async function getFaqEntries(absolutePath: string): Promise<FaqEntry[]> {
+  const raw = await readFile(absolutePath, "utf-8");
+
+  const faqStart = raw.search(/^## FAQ\s*$/m);
+  if (faqStart === -1) return [];
+
+  // The FAQ runs to the next `##` heading, or to the end of the file.
+  const rest = raw.slice(faqStart + 1);
+  const nextSection = rest.search(/^## /m);
+  const section = nextSection === -1 ? rest : rest.slice(0, nextSection);
+
+  const entries: FaqEntry[] = [];
+  let current: { question: string; lines: string[] } | undefined;
+
+  for (const line of section.split("\n")) {
+    const heading = /^### (.+)$/.exec(line);
+
+    if (heading) {
+      if (current) {
+        entries.push({
+          question: toPlainText(current.question),
+          answer: toPlainText(current.lines.join(" ")),
+        });
+      }
+      current = { question: heading[1], lines: [] };
+      continue;
+    }
+
+    if (current) current.lines.push(line);
+  }
+
+  if (current) {
+    entries.push({
+      question: toPlainText(current.question),
+      answer: toPlainText(current.lines.join(" ")),
+    });
+  }
+
+  return entries.filter((entry) => entry.question && entry.answer);
+}
+
+/**
+ * Rounded up, at the 200 wpm that reading-time estimates conventionally assume.
+ */
+export function readingTimeMinutes(content: string): number {
+  const words = content.trim().split(/\s+/).length;
+  return Math.max(1, Math.round(words / 200));
+}
+
+export function formatDate(date: string): string {
+  return new Date(`${date}T00:00:00Z`).toLocaleDateString("en-GB", {
+    day: "numeric",
+    month: "long",
+    year: "numeric",
+    timeZone: "UTC",
+  });
+}

--- a/packages/docs/src/lib/llms.ts
+++ b/packages/docs/src/lib/llms.ts
@@ -1,5 +1,5 @@
 import { readFile } from "node:fs/promises";
-import { source } from "@/lib/source";
+import { getBlogPosts, source } from "@/lib/source";
 
 /**
  * Strips MDX-only syntax so the output reads as plain Markdown.
@@ -107,4 +107,26 @@ export async function getDocEntries(): Promise<DocEntry[]> {
   );
 
   return entries;
+}
+
+/**
+ * Blog posts in the same shape, newest first.
+ *
+ * The `summary` frontmatter is prepended to the body verbatim: it is a direct
+ * answer to the post's title, so a model that truncates still reads the
+ * conclusion rather than the introduction.
+ */
+export async function getBlogEntries(): Promise<DocEntry[]> {
+  return Promise.all(
+    getBlogPosts().map(async (post) => {
+      const raw = await readFile(post.absolutePath, "utf-8");
+
+      return {
+        title: post.data.title,
+        description: post.data.description,
+        url: post.url,
+        content: `In short: ${post.data.summary}\n\n${mdxToPlainMarkdown(raw)}`,
+      };
+    }),
+  );
 }

--- a/packages/docs/src/lib/metadata.ts
+++ b/packages/docs/src/lib/metadata.ts
@@ -84,3 +84,48 @@ export function createMetadata({
     },
   };
 }
+
+export const author = {
+  name: "Alexander Dunlop",
+  url: "https://alexdunlop.com/",
+};
+
+/**
+ * Article metadata — as `createMetadata`, but with `og:type=article` and the
+ * publication dates, which is what social cards and news crawlers read.
+ *
+ * @param path - Absolute site path, e.g. `/blog/some-post`.
+ */
+export function createArticleMetadata({
+  title,
+  description,
+  path,
+  date,
+  updated,
+  keywords = [],
+}: {
+  title: string;
+  description: string;
+  path: string;
+  date: string;
+  updated?: string;
+  keywords?: string[];
+}): Metadata {
+  const base = createMetadata({ title, description, path });
+
+  return {
+    ...base,
+    // Article keywords first, so the page-specific terms lead.
+    keywords: [...keywords, ...siteKeywords],
+    authors: [author],
+    openGraph: {
+      ...base.openGraph,
+      type: "article",
+      // Open Graph wants an ISO 8601 *datetime*; the frontmatter carries a
+      // date, so anchor it to midnight UTC rather than inventing a time.
+      publishedTime: `${date}T00:00:00.000Z`,
+      modifiedTime: `${updated ?? date}T00:00:00.000Z`,
+      authors: [author.url],
+    },
+  };
+}

--- a/packages/docs/src/lib/source.ts
+++ b/packages/docs/src/lib/source.ts
@@ -1,5 +1,6 @@
-import { docs } from '@/.source';
+import { blog as blogPosts, docs } from '@/.source';
 import { loader } from 'fumadocs-core/source';
+import { createMDXSource } from 'fumadocs-mdx';
 
 // See https://fumadocs.vercel.app/docs/headless/source-api for more info
 export const source = loader({
@@ -7,3 +8,21 @@ export const source = loader({
   baseUrl: '/docs',
   source: docs.toFumadocsSource(),
 });
+
+export const blog = loader({
+  baseUrl: '/blog',
+  source: createMDXSource(blogPosts),
+});
+
+export type BlogPost = ReturnType<typeof blog.getPages>[number];
+
+/**
+ * Posts newest-first, then by `order` — the sequence the index, the sitemap,
+ * the feed, and `llms.txt` all use.
+ */
+export function getBlogPosts() {
+  return [...blog.getPages()].sort(
+    (a, b) =>
+      b.data.date.localeCompare(a.data.date) || a.data.order - b.data.order,
+  );
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,6 +93,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      zod:
+        specifier: 3.25.76
+        version: 3.25.76
 
   packages/engine:
     devDependencies:


### PR DESCRIPTION
Follows #90. Three long-form posts aimed at the queries a stranded `react-mentions` user actually types, plus the infrastructure to make them findable.

## Corrections first

The comparison table added in #90 said react-mentions' last release was **2022**. It was **4.4.10 in June 2023** — and the sharper fact is that `github.com/signavio/react-mentions` now returns a **404**, so there is no issue tracker at all. Fixed in both `README.md` and `llm.mdx`. Being wrong about a competitor in the README undercuts exactly the credibility the posts depend on.

## The posts

| Post | Targets |
| --- | --- |
| [How to migrate from react-mentions to mentis](packages/docs/content/blog/migrate-from-react-mentions.mdx) | "react-mentions alternative", "react-mentions unmaintained" |
| [Why mention inputs outgrow the textarea](packages/docs/content/blog/contenteditable-vs-textarea-mention-input.mdx) | "contenteditable vs textarea", the architecture differentiator |
| [The ARIA combobox pattern for @mention autocomplete](packages/docs/content/blog/accessible-mention-autocomplete-aria-combobox.mdx) | "aria-activedescendant", "accessible autocomplete react" |

All three are written against the **verified** API — I read `MentionInput.tsx`, `MentionModal.tsx`, and the type definitions rather than working from the docs, and every claim in them is checkable.

They are also deliberately honest about gaps, because a migration guide that oversells gets found out on the first attempt:

- The migration post says outright that mentis has **no async suggestion loading, no custom suggestion rendering, no multiple triggers per input, and no `singleLine` mode** — and recommends `react-mentions-ts` (a maintained fork, 17.8k weekly downloads) for anyone whose only goal is escaping an unmaintained dependency.
- The accessibility post states that mentis **has no live region announcing result counts**.

Worth a look before merge — that framing is a judgement call and it's yours to make.

## Infrastructure

- **`blog` MDX collection** with required `description` and `summary`, plus `date`, `keywords`, and an `order` tie-break for same-day posts.
- **`summary` does double duty** — rendered as an "In short" block above the article, and lifted verbatim into `llms.txt`. It answers the title outright, so a model that truncates still reads the conclusion rather than the introduction.
- **`TechArticle` + `FAQPage` JSON-LD.** The FAQ entries are extracted from the `## FAQ` / `### question` headings at build time (`src/lib/blog.ts`), so the structured data cannot drift from the prose — edit the post, the rich-result markup follows.
- **Article-type OG metadata** with `article:published_time` / `modified_time` as full ISO datetimes.
- Posts flow into **`sitemap.xml`**, **`llms.txt`** (new `## Articles` section), and **`llms-full.txt`** automatically.
- **`rss.xml`**, linked from the document head.
- `zod` added to `packages/docs` devDependencies for the collection schema.

## Verification

- `pnpm build` — 7/7 tasks, 27 static pages, all three posts prerender.
- `pnpm vitest run` in `packages/mentis` — 86 passed, 5 todo.
- Served the production build and checked the real HTML: JSON-LD parses on all five new/changed pages (`WebSite`+`SoftwareSourceCode`, `Blog`, and `TechArticle`+`FAQPage` ×3); FAQ extraction yields 6/4/5 questions with links stripped to plain text; `og:type=article`, canonical, keywords, and dates present; index, `llms.txt`, and RSS all order the migration post first; all 12 routes return 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)