### PR TITLE
feat(engine): RTL and bidi, which cost the engine almost nothing

### DIFF
--- a/packages/engine/dev/direction-toggle.ts
+++ b/packages/engine/dev/direction-toggle.ts
@@ -1,0 +1,27 @@
+import { need } from "./need";
+
+/**
+ * Flip the editor's writing direction, for looking at RTL and bidi by hand.
+ *
+ * Sets `dir` on the container and nothing else, because that is the entire integration —
+ * the engine has no direction policy and reads the attribute nowhere ([ADR
+ * 0015](../docs/adr/0015-direction-belongs-to-the-consumer.md)). Worth having in the
+ * inspector anyway: the interesting part of bidi is *visual*, and the thing to look at is
+ * the Model panel staying in logical order while the editor reorders on screen.
+ *
+ * Type Hebrew or Arabic and watch the caret. Arrow keys are the browser's (ADR 0003), and
+ * engines genuinely differ about whether ArrowLeft means "visually left" or "logically
+ * back" in mixed text — the model just records whatever selection arrives, which is the
+ * point.
+ */
+export const bindDirectionToggle = (element: HTMLElement): void => {
+  const toggle = need<HTMLInputElement>("#rtl");
+
+  const sync = (): void => {
+    if (toggle.checked) element.setAttribute("dir", "rtl");
+    else element.removeAttribute("dir");
+  };
+
+  toggle.addEventListener("change", sync);
+  sync();
+};

--- a/packages/engine/dev/e2e.ts
+++ b/packages/engine/dev/e2e.ts
@@ -7,6 +7,7 @@ import { mentions } from "../src/model/mentions";
 import { replaceRange } from "../src/model/transaction";
 import { atomNode, textNode } from "../src/model/nodes";
 import type { InlineNode } from "../src/model/types";
+import { positionRect } from "../src/view/position-rect";
 
 /**
  * The e2e harness page — **not** the inspector.
@@ -42,6 +43,15 @@ export interface HarnessNode {
 /** What `reset` accepts: a run of plain text, or a mention. */
 export type Content = string | { label: string; value: string };
 
+/**
+ * Writing direction for the container, for the RTL/bidi specs.
+ *
+ * The engine has no direction policy of its own — direction belongs to the consumer's
+ * container, and the model is logical regardless (ADR 0015). So this sets the attribute
+ * a consumer would set, rather than anything the engine reads.
+ */
+export type Direction = "ltr" | "rtl";
+
 const describeNode = (node: InlineNode): HarnessNode =>
   node.type === "atom"
     ? { type: "atom", text: node.label, value: node.value }
@@ -60,11 +70,19 @@ export interface HarnessModel {
 }
 
 const harness = {
-  /** Rebuild the editor. `content` accepts plain text or a mention spec, in order. */
-  reset(content: Content[] = []): void {
+  /**
+   * Rebuild the editor. `content` accepts plain text or a mention spec, in order.
+   *
+   * `dir` sets the container's writing direction and is **always applied**, cleared when
+   * omitted, so a direction set by one spec can never leak into the next.
+   */
+  reset(content: Content[] = [], dir?: Direction): void {
     editor?.destroy();
     element.replaceChildren();
     unhandled.length = 0;
+
+    if (dir) element.setAttribute("dir", dir);
+    else element.removeAttribute("dir");
 
     editor = createEditor({
       element,
@@ -110,6 +128,20 @@ const harness = {
   /** `inputType`s the engine had no rule for — should be empty in every passing spec. */
   unhandledInput(): string[] {
     return [...unhandled];
+  },
+
+  /**
+   * Where a model position is on screen, via the engine's own `positionRect`.
+   *
+   * The one piece of *geometry* the engine owns, and the only thing a consumer needs in
+   * order to place a mention menu — so it is the only part of ADR 0015's "the engine stays
+   * logical" that a direction can actually break. Returned as plain numbers rather than a
+   * `DOMRect` so it survives the trip out of the page.
+   */
+  positionRect(at: number): { left: number; right: number; width: number } | null {
+    if (!editor) throw new Error("harness: reset() first");
+    const rect = positionRect(element, editor.getState().doc, at);
+    return rect ? { left: rect.left, right: rect.right, width: rect.width } : null;
   },
 };
 

--- a/packages/engine/dev/index.html
+++ b/packages/engine/dev/index.html
@@ -30,6 +30,10 @@
                 ><input type="checkbox" id="engine" checked /> engine
                 attached</label
               >
+              <label
+                title="Sets dir=rtl on the container — the whole of the engine's RTL integration"
+                ><input type="checkbox" id="rtl" /> rtl</label
+              >
             </span>
           </header>
           <div class="panel-body">
@@ -40,6 +44,13 @@
               <strong>engine attached</strong> to fall back to a bare
               <code>contenteditable</code> and compare — the Model panel goes empty
               when detached.
+            </p>
+            <p class="hint">
+              <strong>RTL:</strong> tick <strong>rtl</strong> and type Hebrew or
+              Arabic. The model stays in logical order while the line reorders on
+              screen — and a mention chip keeps its own label direction, so mixed text
+              is bidi, not broken. Direction is the container's; the engine reads it
+              nowhere.
             </p>
             <p class="hint">
               <strong>IME:</strong> during composition the engine deliberately hands

--- a/packages/engine/dev/main.ts
+++ b/packages/engine/dev/main.ts
@@ -1,6 +1,7 @@
 import { createInspector } from "../src/devtools/index";
 import type { Editor } from "../src/editor/types";
 import { bindContentPresets } from "./content-presets";
+import { bindDirectionToggle } from "./direction-toggle";
 import { engineProbe } from "./engine-probe";
 import { bindHistoryControls } from "./history-controls";
 import { bindEngineToggle } from "./engine-toggle";
@@ -26,6 +27,10 @@ const presets = bindContentPresets({
   getEditor: () => editor,
   onApplied: inspector.refresh,
 });
+
+// Independent of the engine toggle: direction is the container's either way, which is
+// itself the demonstration — RTL looks the same attached and detached.
+bindDirectionToggle(element);
 
 const mentionControls = bindMentionControls(() => editor);
 const mentionFlow = bindMentionFlow(element);

--- a/packages/engine/docs/adr/0015-direction-belongs-to-the-consumer.md
+++ b/packages/engine/docs/adr/0015-direction-belongs-to-the-consumer.md
@@ -1,0 +1,134 @@
+# 0015 — Direction belongs to the consumer; the engine stays logical
+
+- **Status:** accepted
+- **Date:** 2026-08-10
+
+## Context
+
+`docs/plan.md` lists "RTL / bidi selection" in M6's nasty-input gauntlet, on the reasonable
+assumption that a contenteditable engine has to do something about it. Bidirectional text is
+where visual order stops matching logical order: a Hebrew line runs right to left, an
+`@Alice` chip inside it runs left to right, and the character that *looks* like it is next to
+the caret may be several offsets away.
+
+Editors do get this wrong, and expensively. The usual cause is code that reasons about
+visual order — "the character to the left of the caret", "the box at x" — because those are
+the terms the user seems to be working in.
+
+So the question for this milestone was what the engine must do about direction. Measuring
+first says: **almost nothing, and that is a result rather than luck.**
+
+### What was measured
+
+`e2e/spec/adr-0015-direction.spec.ts`, on Chromium, Firefox, WebKit and mobile Chrome, with
+Hebrew and Arabic in a `dir="rtl"` container:
+
+- the model is **byte-for-byte identical** in `ltr` and `rtl` for the same content — same
+  text, same length, same nodes, same mention offsets
+- editing RTL text (Backspace, typing) keeps the model and the DOM in step
+- a mention keeps its `value` and its offset in an RTL line; Backspace takes the whole chip;
+  typing beside it disturbs neither; undo restores it as a mention rather than as its label
+- whatever a browser does with arrow keys in mixed text, the resulting selection is always a
+  position the model can represent
+
+None of that needed a change. It falls out of three decisions already made:
+
+| Decision | Why bidi cannot reach it |
+|---|---|
+| [0003](0003-own-editing-not-navigation.md) — navigation stays the browser's | Bidi caret movement is where engines genuinely differ, and the engine never has an opinion to be wrong about |
+| [0004](0004-take-edit-ranges-from-the-browser.md) — ranges from `getTargetRanges()` | The browser resolves what one keypress means in a reordered line |
+| [0005](0005-an-atom-is-one-position-wide.md) — positions are logical offsets | A logical offset has no direction |
+
+## Decision
+
+**The engine has no direction policy. Direction is a property of the consumer's container,
+and the engine reads it nowhere.**
+
+Concretely, and each of these is a thing deliberately *not* done:
+
+- no `dir` attribute is set on the root — the consumer's container already has one, and
+  overriding it would fight the page
+- no `dir` is set on mention chips. A chip's label is ordinary text and the bidi algorithm
+  places it correctly; forcing `dir="ltr"` on an LTR-labelled chip would isolate it from the
+  surrounding run and is the kind of "help" that makes mixed text worse
+- no `unicode-bidi: isolate`, no bidi control characters in the document. Inserting a
+  character the model does not have is the class of fix v1 is made of, and it would break
+  every offset
+- nothing anywhere reads visual order. The single exception is geometry, below
+
+**The one place direction is unavoidable is `positionRect`**, which is the engine's only
+geometry and what a consumer anchors a mention menu to. It gains a direction-aware fallback:
+
+WebKit reports **no client rects at all** for a collapsed range at the end of a text node.
+The previous fallback used the containing element's rect, whose `left` is the far left edge
+— in an RTL line, the wrong end by the entire width of the editor. It now derives the caret
+from the preceding character instead, choosing which edge of that character to sit on **by
+measurement rather than by reading `getComputedStyle(...).direction`** — because the relevant
+direction is the bidi *run's*, not the container's. An RTL word inside an `ltr` container
+computes as `direction: ltr` while being laid out right to left, so the computed value picks
+the wrong edge for exactly the mixed content this exists to serve.
+
+## Alternatives considered
+
+**Set `dir="auto"` on the root and on chips**, so the engine "handles" direction. Rejected:
+it overrides a decision the page already made, and `auto` guesses from first-strong-character
+— so a document that begins with an `@Alice` chip would resolve LTR and flip the whole line
+for an Arabic user. Worse than doing nothing, and harder to explain.
+
+**Track a `direction` field on the document model.** Rejected — it would be a second source
+of truth for something CSS already resolves, it cannot express per-run direction, and every
+consumer would have to keep it in sync with their own container.
+
+**Reason about visual order for arrow keys**, so ArrowLeft always means "one character left".
+Rejected on ADR 0003 grounds, and it is the trap named above: engines already disagree about
+this, users expect their platform's behaviour, and the engine would have to reimplement the
+bidi algorithm to have an opinion at all.
+
+**Read `getComputedStyle(...).direction` in `positionRect`.** Rejected as measured-wrong for
+mixed content, as described above. Measuring two rects is cheaper than being subtly wrong.
+
+## Consequences
+
+Good:
+
+- RTL and bidi cost the engine nothing, and there is now a spec saying so on four engines —
+  so a future change that starts reasoning about visual order fails a test rather than
+  shipping.
+- `positionRect` is correct at the end of a line in RTL on WebKit, where it was previously
+  off by the width of the editor.
+- The M6 bullet closes with evidence rather than an assertion.
+
+Costs and risks:
+
+- **This ADR's value is entirely in the negative claims**, and negative claims rot quietly.
+  The spec asserts the model is *unaffected* by direction, which only stays true while
+  nothing reads `dir` or visual order. That is the thing to protect.
+- `positionRect` now costs two extra rect measurements, but only on the path where it
+  previously returned a wrong answer.
+- The derived fallback assumes the caret sits on one edge of the preceding character. For a
+  position immediately at a bidi *boundary* the caret legitimately has two visual homes, and
+  this picks one. Better than the container's edge; not provably the one the browser would
+  paint.
+
+## Unverified
+
+- **No RTL mention *dropdown* has been placed by hand.** The spec checks `positionRect`
+  returns a rect on the correct side; whether a real menu then looks right — which involves
+  the consumer's own CSS, and the menu overflowing the viewport on the other side — is a
+  consumer concern the harness only approximates.
+- **No vertical writing mode.** `writing-mode: vertical-rl` is a different axis and nothing
+  here has been checked against it. It is not in M6, and inline-only documents make it an
+  odd fit, but `positionRect`'s left/right reasoning would need revisiting.
+- **Bidi + IME together** is untested. Composition hands the DOM to the browser (ADR 0009)
+  and `readDomState` reads it back in logical order, so there is no obvious interaction —
+  but "no obvious interaction" is exactly what ADR 0009 said before it met a real IME.
+
+## Revisit when
+
+- Anything in `src/` starts reading `dir`, `getComputedStyle(...).direction`, or reasoning
+  about visual order — at which point this ADR's central claim is no longer true and the
+  spec should be failing, **or**
+- a consumer reports a mention menu on the wrong side in RTL, which would mean
+  `positionRect`'s rect is right and the *placement* contract around it is not, **or**
+- vertical writing modes come into scope, which would make `positionRect`'s left/right
+  reasoning an axis assumption rather than a direction one.

--- a/packages/engine/docs/notes/contenteditable-traps.md
+++ b/packages/engine/docs/notes/contenteditable-traps.md
@@ -311,3 +311,76 @@ checks whether `dispatchEvent` returned `false` (i.e. a listener called
 browser's real contract — default action happens *unless* keydown was prevented — even
 though the events themselves aren't trusted. It cannot fake composition; test that by
 hand, or in Playwright later.
+
+---
+
+## A collapsed range at the end of a text node has no rects in WebKit
+
+**Symptom.** A dropdown anchored to the caret jumps to the far side of the editor, but
+only in Safari, and only when the caret is at the very end of the text. In an RTL line
+it is wrong by the entire width of the editor, which looks less like a rounding bug and
+more like the anchor was never set.
+
+**Mechanism.** `Range.getClientRects()` returns an **empty list** for a collapsed range
+positioned at the end of a text node in WebKit. Chromium and Firefox return one rect.
+Measured on `"שלום עולם"` in a `dir="rtl"` container:
+
+| position | Chromium | Firefox | WebKit |
+|---|---|---|---|
+| the last character | 1 rect | 1 rect | 1 rect |
+| **after** the last character | 1 rect | 1 rect | **0 rects** |
+
+Any "fall back to the containing element's rect" branch then fires — and an element rect
+is a *line box*, not a caret. Its `left` is the start of the line, which in RTL is the
+opposite end from where the caret actually is.
+
+**What to do.** Derive the caret from the character *before* the position: take a range
+covering that one character, and put the caret on its trailing edge.
+
+Which edge is "trailing" must be **measured, not read from
+`getComputedStyle(...).direction`.** The direction that matters is the bidi *run's*, and
+the computed value is the *container's* — an RTL word inside an `ltr` container computes
+as `ltr` while being laid out right to left, so the computed value picks the wrong edge
+for precisely the mixed content this is needed for. Instead: the caret one character back
+sits at that character's leading edge, so whichever of the character's own edges that
+lands on tells you which way text flows there.
+
+**Where it shows up here.** `src/view/position-rect.ts`, and
+[ADR 0015](../adr/0015-direction-belongs-to-the-consumer.md). Reachable through the
+exported `positionRect` but *not* through the mention menu, which anchors on the `@`
+rather than on the caret and so always gets a rect — which is why it went unnoticed until
+RTL was looked at deliberately.
+
+---
+
+## Arrow keys in bidi text: engines disagree, and it is not yours to settle
+
+**Symptom.** ArrowLeft moves the caret in Firefox and does nothing in Chrome and Safari,
+in the same document, with the same selection.
+
+**Mechanism.** In mixed-direction text, "left" and "back" are different directions, and
+there is no single answer about which an arrow key means. Measured on Hebrew text in a
+`dir="ltr"` container, caret at logical offset 0, pressing ArrowLeft nine times (with
+polling, so a slow `selectionchange` cannot be mistaken for "did not move"):
+
+| | resulting offsets |
+|---|---|
+| Firefox | `1, 2, 3, 4, 5, 6, 7, 8, 9` |
+| Chromium, WebKit | `0, 0, 0, 0, 0, 0, 0, 0, 0` |
+
+Both are defensible: the run is laid out right to left, so its logical start is at the
+run's *right*, and "visually left" and "logically back" genuinely point opposite ways. In
+a `dir="rtl"` container all three engines agree.
+
+**What to do.** Nothing — and specifically, do not assert a caret offset after an arrow
+key in bidi text. [ADR 0003](../adr/0003-own-editing-not-navigation.md) gives navigation
+to the browser precisely so this is never the engine's problem; users get their
+platform's behaviour, which is what they get in every other text field. The assertion
+worth making is the weaker one: *whatever* selection arrives is a position the model can
+represent.
+
+**Where it shows up here.** `e2e/spec/adr-0015-direction.spec.ts` asserts the caret stays
+in range and never lands inside an atom, rather than asserting where it lands. Also worth
+knowing while probing: an unsettled read of the caret right after a keypress produces
+convincing nonsense — an earlier version of this note claimed Chromium repeated and
+skipped offsets in RTL, which was a race in the probe, not a browser behaviour.

--- a/packages/engine/docs/plan.md
+++ b/packages/engine/docs/plan.md
@@ -345,9 +345,39 @@ more of the engine's design constraints to arrive from that direction.
 > expectation, because parked it would have gone on failing for behaviour the engine had
 > decided to keep.
 >
-> Still to do in M6: RTL/bidi, iOS autocorrect and dictation, Android word-level
-> replacement. IME is done for Chromium (above); Gboard is the case that remains, and it is
-> also the one M6 was most worried about.
+> **RTL / bidi: built, and it cost almost nothing.**
+> [ADR 0015](adr/0015-direction-belongs-to-the-consumer.md) — direction belongs to the
+> consumer's container and the engine reads it nowhere.
+>
+> The model is **byte-for-byte identical** in `ltr` and `rtl` for the same content, on all
+> four projects: same text, same length, same nodes, same mention offsets. Editing RTL text,
+> deleting a chip, typing beside one, undo restoring it as a mention — all already correct.
+>
+> That is a consequence rather than luck, and naming the cause is the useful part: ADR 0003
+> gives navigation to the browser, so bidi caret behaviour is never the engine's problem;
+> ADR 0004 takes ranges from `getTargetRanges()`, so the browser resolves what a keypress
+> means in a reordered line; ADR 0005 makes positions logical offsets, which have no
+> direction. Three earlier decisions paying out at once.
+>
+> So the ADR is mostly a set of things deliberately **not** done — no `dir` on the root, none
+> on chips, no bidi control characters, nothing reading visual order — and the spec asserts
+> the model is *unaffected*, which is the claim a future change would break.
+>
+> One real bug found where direction is unavoidable: **`positionRect` was off by the width of
+> the editor at the end of an RTL line in WebKit**, which reports no client rects at all for
+> a collapsed range at the end of a text node, sending it into a fallback that returned the
+> line box's left edge. It now derives the caret from the preceding character, choosing the
+> edge by *measurement* — `getComputedStyle(...).direction` is the container's, and the run's
+> is what matters, so an RTL word in an `ltr` container would pick the wrong side.
+>
+> Also learned, the hard way: an unsettled caret read right after a keypress produces
+> convincing nonsense. A first pass "found" Chromium repeating and skipping offsets in RTL;
+> it was a race in the probe. Both are in the traps note.
+>
+> Still to do in M6: **iOS autocorrect and dictation, and Android word-level replacement** —
+> all of which go through `insertReplacementText`, which is handled but has no real coverage
+> and cannot get any without a device. IME is verified on Chromium (above); **Gboard** is the
+> case that remains, and it is the one M6 was most worried about from the start.
 
 ### M7 — Adapters, as the victory lap
 

--- a/packages/engine/e2e/README.md
+++ b/packages/engine/e2e/README.md
@@ -37,6 +37,7 @@ port-of-its-own convention, same "observe, don't fix" discipline. See `e2e/CLAUD
 | `adr-0009-composition.spec.ts` | IME reconciliation, on a real composition (Chromium) |
 | `adr-0013-graphemes.spec.ts` | whole characters, on the browser's own ranges |
 | `adr-0014-delete-granularity.spec.ts` | the atom clamp, and the grapheme difference kept on purpose |
+| `adr-0015-direction.spec.ts` | RTL/bidi costs the engine nothing — asserted as the model being *unaffected* |
 
 The mirroring is the point. Every ADR carries an **Unverified** section, and this is where
 those get discharged — so a claim cannot quietly outlive its evidence. When a spec settles
@@ -51,8 +52,10 @@ Specs drive `dev/e2e.html` on port **5280** — never `dev/index.html`, which is
 inspector and grows a new panel whenever a milestone needs one. Same split, and the same
 reasoning, as v1's `playground/e2e.html` on 5273.
 
-`window.engineHarness` exposes `reset`, `model`, `insertMention`, `setCaret` and
-`unhandledInput`. It deliberately does **not** expose the `Editor` or `dispatch`: specs
+`window.engineHarness` exposes `reset`, `model`, `insertMention`, `setCaret`,
+`unhandledInput` and `positionRect`. `reset` takes an optional writing direction, always
+applied so one spec's `dir` can never leak into the next. It deliberately does **not**
+expose the `Editor` or `dispatch`: specs
 drive the editor as a user does and read the model to check the result. A spec that could
 set up state the input pipeline cannot produce is a spec that proves something about
 itself.
@@ -96,4 +99,10 @@ phenomenon.
 - **IME on WebKit and Firefox.** `adr-0009-composition.spec.ts` drives a real composition
   through CDP, which is Chromium-only; the other two engines have no equivalent, so those
   specs skip there. Gboard and iOS dictation still need a human at the harness on 5280.
-- **RTL / bidi**, and **Android word-level replacement** — the rest of M6.
+- **iOS autocorrect and dictation, and Android word-level replacement** — the rest of M6.
+  All three arrive as `insertReplacementText`, which the engine handles but which has no
+  real coverage here and cannot get any without a device. Synthesising the event would only
+  check the engine against our own guess at the shape, which is the thing ADR 0009's
+  Unverified section was complaining about before a real IME settled it.
+- **An RTL mention menu placed by hand.** `adr-0015-direction.spec.ts` checks `positionRect`
+  returns a rect on the correct side; how a real menu then looks involves the consumer's CSS.

--- a/packages/engine/e2e/fixtures/harness.ts
+++ b/packages/engine/e2e/fixtures/harness.ts
@@ -7,9 +7,9 @@ import {
 } from "@playwright/test";
 // Type-only, so importing the harness page here never executes it. The page owns these
 // definitions and the global declaration; duplicating them is how the two drift apart.
-import type { Content, HarnessModel, HarnessNode } from "../../dev/e2e";
+import type { Content, Direction, HarnessModel, HarnessNode } from "../../dev/e2e";
 
-export type { Content, HarnessModel, HarnessNode };
+export type { Content, Direction, HarnessModel, HarnessNode };
 
 /**
  * Page object for the engine's browser matrix.
@@ -39,13 +39,35 @@ export class EngineHarness {
 
   // --- setup ---------------------------------------------------------------
 
-  async reset(content: Content[] = []): Promise<void> {
+  /**
+   * `dir` sets the container's writing direction, as a consumer would. The engine reads
+   * it nowhere — that is the claim ADR 0015 makes and `adr-0015-direction.spec.ts` checks.
+   */
+  async reset(content: Content[] = [], dir?: Direction): Promise<void> {
     await this.page.evaluate(
-      (items) => window.engineHarness.reset(items),
-      content as never
+      ({ items, dir: d }) => window.engineHarness.reset(items, d),
+      { items: content, dir } as never
     );
     await this.editor.click();
     await this.setCaretToEnd();
+  }
+
+  /** The container's writing direction as the browser resolved it, not as we set it. */
+  async resolvedDirection(): Promise<string> {
+    return this.editor.evaluate((element) => getComputedStyle(element).direction);
+  }
+
+  /**
+   * Where a model position is on screen, via the engine's own `positionRect` — the one
+   * piece of geometry the engine owns, and what a consumer anchors a mention menu to.
+   */
+  async positionRect(
+    position: number
+  ): Promise<{ left: number; right: number; width: number } | null> {
+    return this.page.evaluate(
+      (at) => window.engineHarness.positionRect(at),
+      position
+    );
   }
 
   // --- reading the model ---------------------------------------------------

--- a/packages/engine/e2e/spec/adr-0015-direction.spec.ts
+++ b/packages/engine/e2e/spec/adr-0015-direction.spec.ts
@@ -1,0 +1,231 @@
+import { expect, test } from "../fixtures/harness";
+
+/**
+ * ADR 0015 — direction belongs to the consumer; the engine stays logical.
+ *
+ * This spec is unusual in this directory: **almost nothing here is a fix.** RTL and bidi
+ * turned out to cost the engine nothing, and that is the claim worth pinning — because it
+ * is a *consequence* of three earlier decisions rather than luck, and a future change
+ * could quietly take it away:
+ *
+ *   - ADR 0003 leaves caret movement to the browser, so bidi caret behaviour — where
+ *     engines genuinely differ — is never the engine's problem
+ *   - ADR 0004 takes edit ranges from `getTargetRanges()`, so the browser resolves what
+ *     one keypress means in a reordered line
+ *   - ADR 0005 makes positions logical offsets, which have no direction at all
+ *
+ * So the assertions are deliberately about the model being *unaffected*. If the engine ever
+ * starts reading `dir`, or deriving anything from visual order, these are what break.
+ *
+ * Hebrew and Arabic rather than a contrived `‮` override: the point is ordinary text
+ * that real users type, not a bidi torture case.
+ */
+
+/** "shalom olam" — 9 characters, strongly RTL. */
+const HEB = "שלום עולם";
+/** "marhaba" — 5 characters, strongly RTL. */
+const AR = "مرحبا";
+
+const ALICE = { label: "@Alice", value: "u_alice" };
+
+test("the container's direction is the whole integration", async ({ harness }) => {
+  // Not a tautology: it establishes that `dir` reaches the element the engine renders
+  // into, so everything below is genuinely running in an RTL box.
+  await harness.reset([HEB], "rtl");
+  expect(await harness.resolvedDirection()).toBe("rtl");
+
+  await harness.reset([HEB]);
+  expect(await harness.resolvedDirection()).toBe("ltr");
+});
+
+test("the model is identical in both directions", async ({ harness }) => {
+  // The headline. Same content, same model — because a position is a logical offset and
+  // has no direction (ADR 0005).
+  const content = [`${HEB} `, ALICE, ` ${AR}`];
+
+  await harness.reset(content, "ltr");
+  const ltr = await harness.model();
+
+  await harness.reset(content, "rtl");
+  const rtl = await harness.model();
+
+  expect(rtl.text).toBe(ltr.text);
+  expect(rtl.length).toBe(ltr.length);
+  expect(rtl.nodes).toEqual(ltr.nodes);
+  expect(rtl.mentions).toEqual(ltr.mentions);
+  await harness.expectModelMatchesDom();
+});
+
+test("editing RTL text keeps the model and the DOM in step", async ({ harness }) => {
+  await harness.reset([HEB], "rtl");
+  await harness.setCaretToEnd();
+
+  await harness.press("{Backspace}{Backspace}");
+  await harness.expectText(HEB.slice(0, -2));
+  await harness.expectModelMatchesDom();
+
+  await harness.type("!");
+  await harness.expectText(`${HEB.slice(0, -2)}!`);
+  await harness.expectModelMatchesDom();
+});
+
+test("a mention keeps its value in an RTL line", async ({ harness }) => {
+  // The whole reason atoms exist. Visual reordering puts the chip somewhere a character
+  // count would not predict, and none of that reaches the model.
+  await harness.reset([`${HEB} `, ALICE, ` ${AR}`], "rtl");
+
+  await expect(harness.chips()).toHaveCount(1);
+  await expect(harness.chips().first()).toHaveAttribute("data-mention-value", "u_alice");
+  expect((await harness.model()).mentions).toEqual([
+    { label: "@Alice", value: "u_alice", at: 10 },
+  ]);
+});
+
+test("Backspace over a chip in RTL takes the whole chip", async ({ harness }) => {
+  await harness.reset([`${HEB} `, ALICE], "rtl");
+  await harness.setCaretToEnd();
+
+  await harness.press("{Backspace}");
+
+  await harness.expectText(`${HEB} `);
+  await expect(harness.chips()).toHaveCount(0);
+  await harness.expectModelMatchesDom();
+});
+
+test("typing beside a chip in RTL disturbs neither", async ({ harness }) => {
+  await harness.reset([`${HEB} `, ALICE], "rtl");
+  await harness.setCaretToEnd();
+
+  await harness.type(AR);
+
+  await harness.expectText(`${HEB} @Alice${AR}`);
+  await expect(harness.chips()).toHaveCount(1);
+  await harness.expectModelMatchesDom();
+});
+
+test("undo in RTL restores exactly what was there", async ({ harness }) => {
+  await harness.reset([`${HEB} `, ALICE], "rtl");
+  await harness.setCaretToEnd();
+
+  await harness.press("{Backspace}");
+  await expect(harness.chips()).toHaveCount(0);
+
+  await harness.undo();
+
+  await harness.expectText(`${HEB} @Alice`);
+  await expect(harness.chips()).toHaveCount(1);
+  // Restored as a *mention*, not as its label text — the reason steps carry slices.
+  expect((await harness.model()).mentions).toEqual([
+    { label: "@Alice", value: "u_alice", at: 10 },
+  ]);
+});
+
+/**
+ * The one place direction could actually break something: `positionRect` is the engine's
+ * only geometry, and what a consumer anchors a mention menu to.
+ */
+test("positionRect anchors inside the editor on the correct side in RTL", async ({
+  harness,
+}) => {
+  await harness.reset([`${HEB} @al`], "rtl");
+
+  const editorBox = await harness.editor.boundingBox();
+  expect(editorBox).not.toBeNull();
+  const { x, width } = editorBox!;
+
+  // Position 10 is the `@` — where `mention-flow.ts` anchors the menu (`active.from`).
+  const rect = await harness.positionRect(10);
+  expect(rect).not.toBeNull();
+
+  // Inside the editor, and in the right half of it: an RTL line starts at the right edge,
+  // so a menu anchored to the left edge would be at the wrong end of the line entirely.
+  expect(rect!.left).toBeGreaterThan(x);
+  expect(rect!.left).toBeLessThan(x + width);
+  expect(rect!.left).toBeGreaterThan(x + width / 2);
+});
+
+test("positionRect anchors on the other side for the same content in LTR", async ({
+  harness,
+}) => {
+  // The mirror, so the test above is measuring direction rather than passing by accident.
+  await harness.reset([`${HEB} @al`], "ltr");
+
+  const editorBox = await harness.editor.boundingBox();
+  const { x, width } = editorBox!;
+
+  const rect = await harness.positionRect(10);
+  expect(rect).not.toBeNull();
+  expect(rect!.left).toBeLessThan(x + width / 2);
+});
+
+test("positionRect is still on the right side at the very end of an RTL line", async ({
+  harness,
+}) => {
+  /*
+   * WebKit reports **no client rects at all** for a collapsed range at the end of a text
+   * node, which sends `positionRect` down its fallback. That fallback used the containing
+   * element's rect, whose `left` is the far *left* edge — the wrong end of an RTL line by
+   * the full width of the editor.
+   *
+   * Not reachable through the mention menu, which anchors on the `@` rather than on the
+   * caret and always gets a rect. Reachable through the exported `positionRect` by any
+   * consumer that wants to place something at the caret, which is the ordinary thing to
+   * want.
+   */
+  await harness.reset([HEB], "rtl");
+  const { length } = await harness.model();
+
+  const editorBox = await harness.editor.boundingBox();
+  const { x, width } = editorBox!;
+
+  const rect = await harness.positionRect(length);
+  expect(rect).not.toBeNull();
+  expect(rect!.left).toBeGreaterThan(x + width / 2);
+});
+
+test("positionRect at the end of an LTR line lands after the last character", async ({
+  harness,
+}) => {
+  // The mirror of the test above, and not redundant: WebKit takes the same derived path
+  // here, so this is what proves the edge is chosen by measurement rather than hardcoded
+  // for RTL. A wrong choice puts the anchor a character-width off, not half a screen, so
+  // it is checked against the text's own extent.
+  await harness.reset(["hello world"], "ltr");
+  const { length } = await harness.model();
+
+  const [atEnd, beforeLast] = await Promise.all([
+    harness.positionRect(length),
+    harness.positionRect(length - 1),
+  ]);
+
+  expect(atEnd).not.toBeNull();
+  expect(beforeLast).not.toBeNull();
+  // The caret after the last character is to the right of the caret before it.
+  expect(atEnd!.left).toBeGreaterThan(beforeLast!.left);
+});
+
+/**
+ * Caret movement is the browser's (ADR 0003), and engines differ about what ArrowLeft
+ * means in mixed text — visually left, or logically back. The engine takes no position on
+ * that, so the claim is not "the caret lands at 3"; it is that **whatever the browser
+ * produces is a position the model can represent**, which is what ADR 0005 needs.
+ */
+test("whatever the browser does with arrows in bidi text, the model can hold it", async ({
+  harness,
+}) => {
+  await harness.reset([`${HEB} `, ALICE, ` ${AR}`], "rtl");
+  const { length } = await harness.model();
+  await harness.setCaret(0);
+
+  for (let index = 0; index < 12; index += 1) {
+    await harness.press("{ArrowLeft}");
+    const head = (await harness.model()).selection?.head;
+    expect(head, `caret after ${index + 1} presses`).not.toBeUndefined();
+    // In range, and never inside the atom — the invariant that would break if a browser
+    // reported a visual position we mapped naively.
+    expect(head).toBeGreaterThanOrEqual(0);
+    expect(head).toBeLessThanOrEqual(length);
+  }
+
+  await harness.expectModelMatchesDom();
+});

--- a/packages/engine/src/view/position-rect.ts
+++ b/packages/engine/src/view/position-rect.ts
@@ -4,10 +4,64 @@ import { modelToDom } from "./model-to-dom";
 /**
  * Where a model position is on screen, for placing a dropdown.
  *
- * A collapsed `Range` reports no client rects in some engines, so this falls back to the
- * rect of the containing node. Returns null only when the position cannot be mapped at
- * all, which callers should treat as "don't move the menu" rather than "put it at 0,0".
+ * Returns null only when the position cannot be mapped at all, which callers should treat
+ * as "don't move the menu" rather than "put it at 0,0".
  */
+
+/** A collapsed range's own rect, or null where the engine reports none. */
+const caretRect = (node: Node, offset: number): DOMRect | null => {
+  const range = document.createRange();
+  try {
+    range.setStart(node, offset);
+    range.collapse(true);
+  } catch {
+    return null;
+  }
+  const rects = range.getClientRects();
+  return rects.length > 0 ? rects[0]! : null;
+};
+
+/**
+ * The caret's position derived from the character *before* it.
+ *
+ * WebKit reports no client rects for a collapsed range at the end of a text node, and the
+ * container's rect is a bad substitute: its `left` is the far left edge, which in an RTL
+ * line is the wrong end by the whole width of the editor.
+ *
+ * Which edge of that character the caret sits on depends on the direction of the text
+ * *there* — and that is **measured rather than read off `getComputedStyle`**, because the
+ * relevant direction is the bidi run's, not the container's. An RTL word inside an
+ * `ltr` container resolves to `direction: ltr` while being laid out right-to-left, so the
+ * computed value would pick the wrong edge for exactly the mixed content this is for.
+ *
+ * The measurement: the caret one character back is at that character's *leading* edge. If
+ * that lands on the character's left, text there flows rightward and the caret we want is
+ * on the right. Otherwise it flows leftward and we want the left.
+ */
+const fromPrecedingCharacter = (node: Node, offset: number): DOMRect | null => {
+  if (node.nodeType !== Node.TEXT_NODE || offset < 1) return null;
+
+  const leading = caretRect(node, offset - 1);
+  if (!leading) return null;
+
+  const span = document.createRange();
+  try {
+    span.setStart(node, offset - 1);
+    span.setEnd(node, offset);
+  } catch {
+    return null;
+  }
+  const character = span.getBoundingClientRect();
+  if (character.width === 0 && character.height === 0) return null;
+
+  const flowsRightward =
+    Math.abs(leading.left - character.left) <=
+    Math.abs(leading.left - character.right);
+  const x = flowsRightward ? character.right : character.left;
+
+  return new DOMRect(x, character.top, 0, character.height);
+};
+
 export const positionRect = (
   root: HTMLElement,
   doc: Doc,
@@ -15,17 +69,14 @@ export const positionRect = (
 ): DOMRect | null => {
   const point = modelToDom(root, doc, position);
 
-  const range = document.createRange();
-  try {
-    range.setStart(point.node, point.offset);
-    range.collapse(true);
-  } catch {
-    return null;
-  }
+  const direct = caretRect(point.node, point.offset);
+  if (direct) return direct;
 
-  const rects = range.getClientRects();
-  if (rects.length > 0) return rects[0]!;
+  const derived = fromPrecedingCharacter(point.node, point.offset);
+  if (derived) return derived;
 
+  // Nothing measurable — an empty editor, or a position with no character behind it. The
+  // containing node's rect is the right line; callers get its leading edge.
   const fallback =
     point.node.nodeType === Node.TEXT_NODE
       ? point.node.parentElement


### PR DESCRIPTION
Closes M6's **RTL / bidi** bullet — with the finding that it needed almost no code, and that this is a *consequence* of three earlier decisions rather than luck.

## The result

The model is **byte-for-byte identical** in `ltr` and `rtl` for the same content, on all four projects — same text, same length, same nodes, same mention offsets. Editing RTL text, deleting a chip, typing beside one, undo restoring it as a mention rather than as its label: all already correct, no change required.

Naming *why* is the useful part, because it's the thing a future change could take away:

| Decision | Why bidi can't reach it |
|---|---|
| [0003](../blob/feat/engine-m6-bidi/packages/engine/docs/adr/0003-own-editing-not-navigation.md) — navigation stays the browser's | Bidi caret movement is where engines actually differ, and the engine never has an opinion to be wrong about |
| [0004](../blob/feat/engine-m6-bidi/packages/engine/docs/adr/0004-take-edit-ranges-from-the-browser.md) — ranges from `getTargetRanges()` | The browser resolves what one keypress means in a reordered line |
| [0005](../blob/feat/engine-m6-bidi/packages/engine/docs/adr/0005-an-atom-is-one-position-wide.md) — positions are logical offsets | A logical offset has no direction |

So [**ADR 0015**](../blob/feat/engine-m6-bidi/packages/engine/docs/adr/0015-direction-belongs-to-the-consumer.md) is mostly a list of things deliberately **not** done — no `dir` on the root, none on chips, no `unicode-bidi: isolate`, no bidi control characters in the document, nothing reading visual order. And the spec asserts the model is *unaffected* by direction, which is precisely the claim that breaks if something starts reading `dir`.

## The one real bug

Direction is unavoidable in exactly one place: `positionRect`, the engine's only geometry and what a consumer anchors a mention menu to.

**WebKit returns no client rects at all for a collapsed range at the end of a text node.** The old fallback used the containing element's rect — a *line box*, not a caret — whose `left` is the start of the line. In RTL that's the wrong end by the entire width of the editor:

```
RTL, caret after the last character:  expected > 640,  received 16
```

It now derives the caret from the preceding character, and picks which edge to sit on **by measurement rather than by reading `getComputedStyle(...).direction`** — because the direction that matters is the bidi *run's*, not the container's. An RTL word inside an `ltr` container computes as `direction: ltr` while being laid out right to left, so the computed value picks the wrong side for exactly the mixed content this exists to serve.

Confirmed red first: WebKit only, Chromium and Firefox unaffected. Also confirmed the RTL assertions are direction-sensitive rather than passing by luck — forcing the fallback path makes them fail.

Worth being clear that this was **not reachable through the mention menu**, which anchors on the `@` rather than the caret and so always gets a rect. It's reachable through the exported `positionRect` by any consumer wanting to place something at the caret, which is the ordinary thing to want — and it's why this went unnoticed until RTL was looked at deliberately.

## A probe that lied

A first pass "found" Chromium repeating and skipping caret offsets in RTL, which would have been a great trap note. It was a **race in the probe** — reading the caret before `selectionchange` settled. With polling, all three engines walk RTL identically.

The real arrow-key difference is elsewhere and is in the traps note: Hebrew in a `dir="ltr"` container, ArrowLeft from offset 0 moves in Firefox (`1,2,3…`) and does nothing in Chromium and WebKit (`0,0,0…`). Both defensible — "visually left" and "logically back" point opposite ways in an RTL run. So the spec asserts the caret stays in range and never lands inside an atom, rather than asserting where it lands.

## Also in here

- **A `dir` toggle in the inspector**, so this is demonstrable by hand — tick it and type Hebrew, and watch the Model panel stay logical while the line reorders.
- **A `dir` argument on the e2e harness `reset`**, always applied so one spec's direction can never leak into the next, plus a `positionRect` helper on the fixture.

## Numbers

- **436 unit tests**, unchanged — this is geometry and integration, and happy-dom does no layout
- **248 e2e passing / 24 skipped** (was 200 / 24). Skips are still only the Chromium-only composition specs on Firefox and WebKit
- Typecheck and e2e typecheck clean; inspector boots with no console errors

## Still unverified

- **No RTL mention *menu* placed by hand.** The spec checks the rect is on the correct side; how a real menu looks involves the consumer's CSS and viewport overflow.
- **No vertical writing mode.** Not in M6, and `positionRect`'s left/right reasoning would need revisiting for it.
- **Bidi + IME together.** No obvious interaction, which is exactly what ADR 0009 said before it met a real IME.

## Test by hand

Optional — the automated matrix covers all four engines, and there's no browser-specific manual gap here the way there was for #89 and #93. If you want to look:

`pnpm --filter @mentis/engine dev`, tick **rtl** in the Editor panel header, type Hebrew or Arabic, insert an `@Alice` chip mid-sentence. The chip should read left-to-right inside a right-to-left line, the Model panel should stay in logical order, and ⌘Z should undo the chip in one step.

## What's left in M6

**iOS autocorrect and dictation, and Android word-level replacement.** All three arrive as `insertReplacementText`, which the engine handles but which has no real coverage and can't get any without a device — synthesising the event would only check the engine against our own guess at its shape. Gboard is the case this milestone was most worried about from the start, and it's the one still standing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
