### PR TITLE
fix(engine): a keypress that changed nothing is not an undo step

### DIFF
--- a/packages/engine/docs/adr/0004-take-edit-ranges-from-the-browser.md
+++ b/packages/engine/docs/adr/0004-take-edit-ranges-from-the-browser.md
@@ -122,3 +122,17 @@ That last part is this ADR's own *revisit-when* firing exactly as written — "a
 found reporting target ranges that disagree with what it actually intends to change" — so
 the exception is the rule working, not the rule breaking. An atom is the engine's own
 construct (ADR 0005), not a platform text convention, which is the line ADR 0014 draws.
+
+### A consequence of "delete nothing" that took a while to surface
+
+This ADR's rule that a collapsed browser range means *delete nothing* is still right, and it
+had a second-order cost nobody had looked for. Chromium and Firefox fire
+`deleteContentForward` with a collapsed range whenever there is nothing ahead of the caret,
+so the engine dutifully built a **zero-step transaction** — and the history layer recorded
+it. Pressing Delete at the end of a document therefore burned an undo step, split the word
+being typed, and cleared the redo branch, losing undone work outright.
+
+Fixed in `history/record` rather than here, because the range handling was not the mistake:
+see [ADR 0008](0008-undo-granularity-is-word-based.md)'s verification section. The lesson
+belongs to this ADR too, though — **"the browser sent an event" is not "the document
+changed"**, and a rule that deliberately produces no-ops needs its consumers to know that.

--- a/packages/engine/docs/adr/0008-undo-granularity-is-word-based.md
+++ b/packages/engine/docs/adr/0008-undo-granularity-is-word-based.md
@@ -77,9 +77,47 @@ Costs and risks:
 - **Unverified in a real browser.** The rule is tested at the model level; whether it
   *feels* right is exactly the judgement the harness exists for.
 
+## Verification, 2026-08-10
+
+**Confirmed on Chromium, Firefox, WebKit and mobile Chrome**
+(`e2e/spec/adr-0008-undo-granularity.spec.ts`), against real keystrokes rather than
+dispatched transactions: a word is one undo step, each word is its own step, redo replays
+the same grouping, and a mention is its own step however small.
+
+**And it found a bug that was not a granularity bug at all — it was hiding inside one.**
+
+**A keypress that changed nothing was recorded as an undo step.** [ADR
+0004](0004-take-edit-ranges-from-the-browser.md) reads a collapsed range from the browser as
+*"delete nothing — that is information, not an omission"*, and Chromium and Firefox do fire
+`deleteContentForward` with one when there is nothing ahead of the caret. So the engine
+correctly did nothing to the document and then recorded having done nothing. Pressing Delete
+four times at the end of a document took the history from depth 2 to depth 6.
+
+It cost three things, in increasing order of seriousness:
+
+1. **A dead undo press** per dead keystroke — ⌘Z that visibly does nothing.
+2. **A split typing run.** A dead keystroke mid-word ended the group, so `hi` + a no-op +
+   `gh` was two undo steps instead of one. Directly contrary to this ADR's central claim.
+3. **The redo branch.** `record` clears it, so an undone edit became unrecoverable: type,
+   undo, press Delete at the end, press redo — the text was gone for good. That one is data
+   loss, not an annoyance.
+
+The fix is a guard in `record`: an entry with no `undoSteps` and no `redoSteps` is not an
+edit and is not recorded. WebKit fires no `beforeinput` at all in that situation, so it never
+saw the keyboard route — but it reached the same bug through a **selection-only
+transaction**, which is an ordinary thing for a consumer or an M7 adapter to dispatch to move
+the caret. One guard covers both routes.
+
+Worth noting what this says about the design: the engine was *right* twice over — right to
+treat a collapsed range as "delete nothing", and right to build a transaction for it — and
+the bug was in treating "a transaction happened" as "an edit happened". Those are not the
+same event, and nothing had said so.
+
 ## Revisit when
 
 - Punctuation grouping grates in real use, **or**
 - deletion runs turn out to want word boundaries too, at which point `editShapeOf` needs
   the deleted text — which it currently does not capture, since a delete step is only a
-  range.
+  range, **or**
+- a transaction appears that changes the document without producing steps, which would make
+  `record`'s "no steps means no edit" guard wrong rather than merely narrow.

--- a/packages/engine/docs/adr/0009-yield-the-dom-during-composition.md
+++ b/packages/engine/docs/adr/0009-yield-the-dom-during-composition.md
@@ -116,15 +116,39 @@ Chromium only, so this is Chromium's idea of the event sequence. Specifically st
 untested:
 
 - Japanese and Chinese input on **WebKit and Firefox**, which have no CDP equivalent
-- **Gboard on Android**, which composes far more aggressively and is the case this ADR
-  called out as the aggressive one
-- iOS dictation and autocorrect
+- iOS dictation and autocorrect, which arrive as `insertReplacementText` rather than as a
+  composition and have no automatable route at all — CDP has no spellcheck-correction
+  command, and synthesising the event would only check the engine against our own guess at
+  its shape, which is the objection this whole section started as
 - whether a trailing `beforeinput` arrives after `compositionend` on *those* engines — it
   does not on Chromium, but that is where the doubt was cheapest to remove, not where it
   was largest
 
 A human at a keyboard with a Japanese input source is still the only way to close those,
 and the harness on port 5280 is where to do it.
+
+### Word-level replacement — verified 2026-08-10, and it was reachable after all
+
+**Gboard was on this list, and the mechanism turned out to be drivable.**
+`Input.imeSetComposition` accepts `replacementStart`/`replacementEnd`, which is the actual
+Android mechanism for rewriting the word behind the caret — a composition that replaces an
+existing range rather than inserting at the caret. Not an approximation of Gboard; the same
+shape of input, and nothing faked at the DOM level.
+
+Three specs, on Chromium and mobile Chrome:
+
+- replacing `teh` with `the` reconciles correctly, model and DOM in step, no stray
+  `insertCompositionText`
+- **a replaced word is one undo step** — two DOM edits, one history entry
+- a replacement range deliberately stretched across a mention **cannot destroy the chip**:
+  Chromium clamps its own replacement range at the `contenteditable="false"` boundary and
+  refuses to compose across it, so the mention keeps its `value`. Inherited protection, the
+  same pattern as ADR 0005's arrow traversal and whole-chip delete
+
+What is still out of reach is not the mechanism but the *policy* — when a real Gboard decides
+to fire one, how much text it takes, and what it does with a chip in the middle. That needs a
+device. The aggressive case is no longer entirely unexercised, though, which is what this
+list said it was.
 
 ## Original unverified note, kept for the record
 

--- a/packages/engine/docs/notes/contenteditable-traps.md
+++ b/packages/engine/docs/notes/contenteditable-traps.md
@@ -384,3 +384,54 @@ in range and never lands inside an atom, rather than asserting where it lands. A
 knowing while probing: an unsettled read of the caret right after a keypress produces
 convincing nonsense — an earlier version of this note claimed Chromium repeated and
 skipped offsets in RTL, which was a race in the probe, not a browser behaviour.
+
+---
+
+## A keypress that changes nothing still fires `beforeinput`
+
+**Symptom.** Undo appears broken. ⌘Z does nothing — once, twice, four times — and then
+suddenly works. Or worse: you undo, press a key that does nothing, press redo, and the
+work you undid is gone for good.
+
+**Mechanism.** Two things that are individually reasonable.
+
+Browsers fire `beforeinput` for edits that have nothing to edit. Caret at the end of the
+document, press Delete: **Chromium and Firefox fire `deleteContentForward` with a
+collapsed target range.** WebKit fires nothing at all.
+
+| | Delete with nothing ahead of the caret |
+|---|---|
+| Chromium, Firefox | `deleteContentForward`, target range collapsed |
+| WebKit | no `beforeinput` |
+
+A collapsed range from the browser genuinely means *delete nothing* — widening it is how a
+word delete becomes a character delete
+([ADR 0004](../adr/0004-take-edit-ranges-from-the-browser.md)). So the correct handling
+produces a transaction with **no steps**. And then the history layer records it, because
+"a transaction was applied" reads like "an edit happened".
+
+Recording it costs three things, worst last:
+
+1. a dead undo press, one per dead keystroke
+2. a **split typing run** — a no-op mid-word ends the group, so one word becomes two undo
+   steps
+3. the **redo branch**, if recording clears it. Undone work becomes unrecoverable
+
+**What to do.** Guard where the edit is *recorded*, not where the event is handled — the
+event handling is right, and every source of no-op transactions gets fixed at once. An
+entry with no undo steps and no redo steps is not an entry.
+
+Note the keyboard is not the only route: a **selection-only transaction** — moving the
+caret programmatically, which any adapter will want to do — has no steps either, and hits
+every engine including WebKit. If you only test with a keyboard you will conclude this is
+a Chromium and Firefox problem.
+
+**What to watch for when testing.** Assert the history is *unchanged*, not that it grew by
+a specific amount. Depth deltas differ across engines here precisely because WebKit does
+not send the event, so an exact-count assertion passes on WebKit for the wrong reason.
+
+**Where it shows up here.** `src/history/history-state.ts`, and
+`e2e/spec/adr-0008-undo-granularity.spec.ts`. Found while giving
+[ADR 0008](../adr/0008-undo-granularity-is-word-based.md) its first browser coverage —
+which is the argument for discharging *Unverified* sections even when you expect them to
+pass, because this had been shipping since M3.

--- a/packages/engine/docs/plan.md
+++ b/packages/engine/docs/plan.md
@@ -374,10 +374,42 @@ more of the engine's design constraints to arrive from that direction.
 > convincing nonsense. A first pass "found" Chromium repeating and skipping offsets in RTL;
 > it was a race in the probe. Both are in the traps note.
 >
-> Still to do in M6: **iOS autocorrect and dictation, and Android word-level replacement** —
-> all of which go through `insertReplacementText`, which is handled but has no real coverage
-> and cannot get any without a device. IME is verified on Chromium (above); **Gboard** is the
-> case that remains, and it is the one M6 was most worried about from the start.
+> **Word-level replacement: reachable after all, and it works.** CDP's
+> `Input.imeSetComposition` takes `replacementStart`/`replacementEnd` — which *is* the
+> Android mechanism, a composition that replaces an existing range rather than inserting at
+> the caret. So Gboard's aggressive case is drivable on Chromium and mobile Chrome without
+> faking anything, the same argument that made M4's IME verification worth doing.
+>
+> Two things came out of pointing it at the engine. Replacing `teh` with `the` reconciles
+> correctly and is **one** undo step. And a replacement range deliberately stretched across a
+> mention **cannot destroy the chip** — Chromium clamps its own replacement range at the
+> `contenteditable="false"` boundary and refuses to compose across it, so the mention keeps
+> its `value`. That is ADR 0005's pattern again: the protection is inherited rather than
+> implemented.
+>
+> **The real find was somewhere else, and it had been shipping since M3.** Giving
+> [ADR 0008](adr/0008-undo-granularity-is-word-based.md) its first browser coverage — a claim
+> nobody expected to fail — turned up that **a keypress which changed nothing was recorded as
+> an undo step.** ADR 0004 reads a collapsed browser range as "delete nothing", and Chromium
+> and Firefox fire `deleteContentForward` with one whenever there is nothing ahead of the
+> caret, so the engine built a zero-step transaction and the history recorded it. Delete at
+> the end of a document four times took the stack from depth 2 to 6.
+>
+> It cost a dead ⌘Z per keystroke, it **split the word being typed** — directly against ADR
+> 0008's central claim — and it **cleared the redo branch**, making undone work
+> unrecoverable. That last one is data loss. One guard in `record` fixes all three, and also
+> the route WebKit reaches it by: a selection-only transaction, which any M7 adapter will
+> dispatch to move the caret.
+>
+> The engine was right twice and still wrong: right that a collapsed range means delete
+> nothing, right to build a transaction for it — and wrong to treat *a transaction happened*
+> as *an edit happened*. Nothing had said those were different events.
+>
+> Still to do in M6: **iOS autocorrect and dictation**, which arrive as
+> `insertReplacementText` rather than as a composition and have no automatable route at all —
+> CDP has no spellcheck-correction command, and synthesising the event would only check the
+> engine against our own guess at its shape. That plus **real Gboard on a real device** is
+> what is left, and both need a human with a phone rather than another spec.
 
 ### M7 — Adapters, as the victory lap
 

--- a/packages/engine/e2e/README.md
+++ b/packages/engine/e2e/README.md
@@ -33,6 +33,7 @@ port-of-its-own convention, same "observe, don't fix" discipline. See `e2e/CLAUD
 |---|---|
 | `adr-0001-newlines.spec.ts` | one `\n` per break, rendered as text, one trailing `<br>` |
 | `adr-0005-atoms.spec.ts` | a chip is one caret stop; the two coordinate spaces diverge |
+| `adr-0008-undo-granularity.spec.ts` | a word is one undo step — and a keypress that changed nothing is none |
 | `adr-0010-clipboard.spec.ts` | the round trip, through a real system clipboard |
 | `adr-0009-composition.spec.ts` | IME reconciliation, on a real composition (Chromium) |
 | `adr-0013-graphemes.spec.ts` | whole characters, on the browser's own ranges |
@@ -54,7 +55,9 @@ reasoning, as v1's `playground/e2e.html` on 5273.
 
 `window.engineHarness` exposes `reset`, `model`, `insertMention`, `setCaret`,
 `unhandledInput` and `positionRect`. `reset` takes an optional writing direction, always
-applied so one spec's `dir` can never leak into the next. It deliberately does **not**
+applied so one spec's `dir` can never leak into the next. The fixture adds composition on top
+via CDP — `compose`, `composeReplacing` (Android word-level replacement), `commitComposition`
+— which is Chromium-only. It deliberately does **not**
 expose the `Editor` or `dispatch`: specs
 drive the editor as a user does and read the model to check the result. A spec that could
 set up state the input pipeline cannot produce is a spec that proves something about
@@ -99,10 +102,14 @@ phenomenon.
 - **IME on WebKit and Firefox.** `adr-0009-composition.spec.ts` drives a real composition
   through CDP, which is Chromium-only; the other two engines have no equivalent, so those
   specs skip there. Gboard and iOS dictation still need a human at the harness on 5280.
-- **iOS autocorrect and dictation, and Android word-level replacement** — the rest of M6.
-  All three arrive as `insertReplacementText`, which the engine handles but which has no
-  real coverage here and cannot get any without a device. Synthesising the event would only
-  check the engine against our own guess at the shape, which is the thing ADR 0009's
-  Unverified section was complaining about before a real IME settled it.
+- **iOS autocorrect and dictation.** These arrive as `insertReplacementText` rather than as
+  a composition, and there is no automatable route — CDP has no spellcheck-correction
+  command, and synthesising the event would only check the engine against our own guess at
+  its shape, which is the thing ADR 0009's Unverified section was complaining about before a
+  real IME settled it.
+- **Real Gboard.** The *mechanism* is covered — `harness.composeReplacing` drives Android
+  word-level replacement through `replacementStart`/`replacementEnd` on Chromium and mobile
+  Chrome, which is what Gboard actually does. What needs a device is its *policy*: when it
+  fires, how much it takes, and what it does with a chip in range.
 - **An RTL mention menu placed by hand.** `adr-0015-direction.spec.ts` checks `positionRect`
   returns a rect on the correct side; how a real menu then looks involves the consumer's CSS.

--- a/packages/engine/e2e/fixtures/harness.ts
+++ b/packages/engine/e2e/fixtures/harness.ts
@@ -253,6 +253,25 @@ export class EngineHarness {
     });
   }
 
+  /**
+   * Compose text that **replaces an existing range** rather than inserting at the caret.
+   *
+   * This is Android word-level replacement — what Gboard does when it rewrites the word
+   * behind the caret — and `replacementStart`/`replacementEnd` is the actual mechanism, not
+   * an approximation of one. Offsets are DOM character offsets, as CDP expects.
+   */
+  async composeReplacing(text: string, from: number, to: number): Promise<void> {
+    await this.ensureFocused();
+    const cdp = await this.session();
+    await cdp.send("Input.imeSetComposition", {
+      text,
+      selectionStart: text.length,
+      selectionEnd: text.length,
+      replacementStart: from,
+      replacementEnd: to,
+    });
+  }
+
   /** Commit the composition — picking the candidate. Fires `compositionend`. */
   async commitComposition(text: string): Promise<void> {
     const cdp = await this.session();

--- a/packages/engine/e2e/spec/adr-0008-undo-granularity.spec.ts
+++ b/packages/engine/e2e/spec/adr-0008-undo-granularity.spec.ts
@@ -1,0 +1,148 @@
+import { expect, test } from "../fixtures/harness";
+
+/**
+ * ADR 0008 — undo granularity follows words, not typing speed.
+ *
+ * Its Consequences section closes with the doubt this spec exists to remove:
+ *
+ * > **Unverified in a real browser.** The rule is tested at the model level; whether it
+ * > *feels* right is exactly the judgement the harness exists for.
+ *
+ * Two halves here. The first pins the rule itself against real keystrokes. The second
+ * covers what looking at it in a browser actually turned up: **a keypress that changed
+ * nothing was recorded as an undo step**, which is not a granularity question but was
+ * hiding inside one.
+ */
+
+const ALICE = { label: "@Alice", value: "u_1" };
+
+// --- the rule ---------------------------------------------------------------
+
+test("a word is one undo step", async ({ harness }) => {
+  await harness.reset([]);
+  await harness.type("hello");
+
+  await harness.undo();
+
+  await harness.expectText("");
+});
+
+test("each word is its own undo step", async ({ harness }) => {
+  await harness.reset([]);
+  await harness.type("one two three");
+
+  await harness.undo();
+  await harness.expectText("one two ");
+
+  await harness.undo();
+  await harness.expectText("one ");
+
+  await harness.undo();
+  await harness.expectText("");
+});
+
+test("redo replays the same grouping", async ({ harness }) => {
+  await harness.reset([]);
+  await harness.type("one two");
+
+  await harness.undo();
+  await harness.expectText("one ");
+
+  await harness.redo();
+  await harness.expectText("one two");
+  await harness.expectModelMatchesDom();
+});
+
+test("a mention is its own undo step, however small", async ({ harness }) => {
+  // `origin: "program"` never coalesces, so a chip cannot be swallowed by the word it
+  // was typed next to.
+  await harness.reset(["hi "]);
+  await harness.setCaretToEnd();
+  await harness.insertMention(ALICE.label, ALICE.value);
+  await expect(harness.chips()).toHaveCount(1);
+
+  await harness.undo();
+
+  await harness.expectText("hi ");
+  await expect(harness.chips()).toHaveCount(0);
+});
+
+// --- a keypress that changed nothing ----------------------------------------
+
+/**
+ * ADR 0004 reads a collapsed range from the browser as "delete nothing — that is
+ * information, not an omission". Chromium and Firefox *do* fire `deleteContentForward`
+ * with one when there is nothing ahead of the caret; WebKit fires no `beforeinput` at all.
+ *
+ * So the engine correctly did nothing to the document, and then recorded having done
+ * nothing. Asserting the history is *unchanged* covers all three engines without caring
+ * which of them bothered to send the event.
+ */
+test("Delete with nothing ahead of the caret leaves the history alone", async ({
+  harness,
+}) => {
+  await harness.reset([]);
+  await harness.type("abc");
+  const { history } = await harness.model();
+
+  await harness.press("{Delete}{Delete}{Delete}{Delete}");
+
+  expect((await harness.model()).history.depth).toBe(history.depth);
+  await harness.expectText("abc");
+});
+
+test("Backspace at the start of the document leaves the history alone", async ({
+  harness,
+}) => {
+  await harness.reset(["abc"]);
+  await harness.setCaret(0);
+  const { history } = await harness.model();
+
+  await harness.press("{Backspace}{Backspace}{Backspace}");
+
+  expect((await harness.model()).history.depth).toBe(history.depth);
+  await harness.expectText("abc");
+});
+
+test("a dead keypress does not cost an undo press", async ({ harness }) => {
+  // What the user sees: ⌘Z once per dead keystroke, each doing visibly nothing, before
+  // undo starts working again.
+  await harness.reset([]);
+  await harness.type("abc");
+  await harness.press("{Delete}{Delete}{Delete}");
+
+  await harness.undo();
+
+  await harness.expectText("");
+});
+
+test("a dead keypress does not destroy the redo branch", async ({ harness }) => {
+  // The serious one. `record` clears the redo branch, so this made undone work
+  // unrecoverable: type, undo, press Delete at the end, press redo — gone for good.
+  await harness.reset([]);
+  await harness.type("abc");
+
+  await harness.undo();
+  await harness.expectText("");
+
+  await harness.setCaretToEnd();
+  await harness.press("{Delete}");
+
+  await harness.redo();
+
+  await harness.expectText("abc");
+  await harness.expectModelMatchesDom();
+});
+
+test("a dead keypress does not split the word being typed", async ({ harness }) => {
+  // The subtlest symptom, and the one a fix could easily trade for: an unrecorded
+  // keystroke must not interrupt the run either side of it, or `hi` becomes two steps.
+  await harness.reset([]);
+  await harness.type("hi");
+  await harness.press("{Delete}");
+  await harness.type("gh");
+
+  await harness.undo();
+
+  await harness.expectText("");
+});

--- a/packages/engine/e2e/spec/adr-0009-composition.spec.ts
+++ b/packages/engine/e2e/spec/adr-0009-composition.spec.ts
@@ -209,3 +209,71 @@ test("no stray insertCompositionText reaches the engine unhandled", async ({
 
   expect(await harness.unhandledInput()).toEqual([]);
 });
+
+/**
+ * Android word-level replacement — the aggressive case M6 was most worried about.
+ *
+ * `Input.imeSetComposition` takes `replacementStart`/`replacementEnd`, which is the actual
+ * mechanism Gboard uses to rewrite the word behind the caret rather than an approximation
+ * of it. So the shape of input the plan called "the boss fight" is drivable here, and only
+ * a real device's *choice* of when to fire it is out of reach.
+ */
+test("a composition that replaces a word reconciles to the new word", async ({
+  harness,
+}) => {
+  await harness.reset(["teh cat"]);
+  await harness.setCaret(3);
+
+  await harness.composeReplacing("the", 0, 3);
+  await harness.commitComposition("the");
+
+  await harness.expectText("the cat");
+  await harness.expectModelMatchesDom();
+  expect(await harness.unhandledInput()).toEqual([]);
+});
+
+test("a replaced word is a single undo step", async ({ harness }) => {
+  // The claim that makes reconciling worth doing rather than replacing the document. A
+  // word-level replacement is two edits in the DOM — remove, insert — and must be one here.
+  await harness.reset([]);
+  await harness.type("teh");
+  await harness.setCaret(3);
+
+  await harness.composeReplacing("the", 0, 3);
+  await harness.commitComposition("the");
+  await harness.expectText("the");
+
+  await harness.undo();
+
+  await harness.expectText("teh");
+  await harness.expectModelMatchesDom();
+});
+
+test("a replacement range stretched across a mention cannot destroy it", async ({
+  harness,
+}) => {
+  /*
+   * Deliberately asking for something dangerous: a replacement spanning the chip. If it
+   * were honoured, `replaceRange` would delete the atom and insert plain text — a mention
+   * silently degraded to its label, the bug class this engine exists to prevent.
+   *
+   * It cannot happen, and not because the engine checks: **Chromium clamps its own
+   * replacement range at the `contenteditable="false"` boundary** and will not compose
+   * across it. Same shape as ADR 0005's other protections — arrow traversal and whole-chip
+   * delete are inherited from the atom being uneditable, not implemented.
+   *
+   * Asserted as "the mention survives with its value" rather than as an exact document,
+   * because how much of the surrounding text a browser chooses to replace is its business.
+   */
+  await harness.reset(["hi ", ALICE, " teh"]);
+  await harness.setCaretToEnd();
+
+  await harness.composeReplacing("XXXX", 0, 8);
+  await harness.commitComposition("XXXX");
+
+  await expect(harness.chips()).toHaveCount(1);
+  expect((await harness.model()).mentions).toEqual([
+    expect.objectContaining({ label: "@Alice", value: "u_1" }),
+  ]);
+  await harness.expectModelMatchesDom();
+});

--- a/packages/engine/src/history/history-state.ts
+++ b/packages/engine/src/history/history-state.ts
@@ -16,6 +16,20 @@ interface RecordOptions {
  * Recording **clears the redo branch**. Editing after an undo abandons the future that
  * was undone — keeping it would let redo replay steps whose positions no longer refer to
  * anything in the current document.
+ *
+ * A transaction that changed **nothing** is not an edit and is not recorded. That is not a
+ * defensive check; it is reachable from the keyboard. [ADR
+ * 0004](../../docs/adr/0004-take-edit-ranges-from-the-browser.md) reads a collapsed range
+ * from the browser as "delete nothing — that is information, not an omission", and
+ * Chromium and Firefox *do* fire `deleteContentForward` with one when there is nothing
+ * ahead of the caret. So pressing Delete at the end of a document produced a zero-step
+ * transaction, and recording it cost the user two things:
+ *
+ *   - **a dead undo press** — ⌘Z that visibly does nothing, once per keystroke
+ *   - **their redo branch**, because recording clears it. Type, undo, press Delete at the
+ *     end, press redo: the text was gone for good
+ *
+ * The second is data loss, which is why this guard is here rather than in the caller.
  */
 export const record = (
   state: HistoryState,
@@ -23,6 +37,8 @@ export const record = (
   shape: EditShape,
   { maxDepth = DEFAULT_MAX_DEPTH, maxIdleMs, maxGroupSize }: RecordOptions = {}
 ): HistoryState => {
+  if (entry.undoSteps.length === 0 && entry.redoSteps.length === 0) return state;
+
   const previous = state.done[state.done.length - 1];
 
   const done = canCoalesce(previous, shape, entry.at, { maxIdleMs, maxGroupSize })

--- a/packages/engine/src/history/tests/history-state.test.ts
+++ b/packages/engine/src/history/tests/history-state.test.ts
@@ -50,6 +50,38 @@ const add = (state: HistoryState, transaction: Transaction, at: number) => {
   return record(state, next, shape);
 };
 
+/**
+ * A transaction that changed nothing, built the way `create-editor`'s `apply` builds one:
+ * no steps, so the inverse has none either.
+ *
+ * Reachable from the keyboard, not hypothetical — Chromium and Firefox fire
+ * `deleteContentForward` with a collapsed range when there is nothing ahead of the caret,
+ * and `transactionFor` turns that into exactly this.
+ */
+const addNothing = (state: HistoryState, at: number) => {
+  const transaction: Transaction = {
+    steps: [],
+    selection: { anchor: 3, head: 3 },
+    origin: "user",
+  };
+  const shape = editShapeOf(transaction);
+  return record(
+    state,
+    {
+      undoSteps: [],
+      redoSteps: [],
+      selectionBefore: null,
+      selectionAfter: transaction.selection ?? null,
+      kind: shape.kind,
+      endedAt: shape.endedAt,
+      size: shape.size,
+      char: shape.char,
+      at,
+    },
+    shape
+  );
+};
+
 describe("editShapeOf", () => {
   it("classifies a single typed character as type", () => {
     expect(editShapeOf(typed(3))).toEqual({
@@ -193,6 +225,51 @@ describe("mergeEntries", () => {
     const merged = mergeEntries(a, b);
     expect(merged.selectionBefore).toEqual({ anchor: 0, head: 0 });
     expect(merged.selectionAfter).toEqual({ anchor: 2, head: 2 });
+  });
+});
+
+describe("record — a transaction that changed nothing", () => {
+  it("is not recorded, so undo is never a keypress that does nothing", () => {
+    let state = emptyHistory();
+    state = add(state, typed(0, "a"), 1000);
+    const depth = state.done.length;
+
+    state = addNothing(state, 2000);
+    state = addNothing(state, 3000);
+    state = addNothing(state, 4000);
+
+    expect(state.done).toHaveLength(depth);
+  });
+
+  it("does not destroy the redo branch", () => {
+    // The serious half: `record` clears `undone`, so a keypress that did nothing made an
+    // undone edit unrecoverable. Type, undo, press Delete at the end, press redo — gone.
+    let state = emptyHistory();
+    state = add(state, typed(0, "a"), 1000);
+    const undone = undo(state)!.state;
+    expect(canRedo(undone)).toBe(true);
+
+    const after = addNothing(undone, 2000);
+
+    expect(canRedo(after)).toBe(true);
+    expect(redo(after)).not.toBeNull();
+  });
+
+  it("leaves the state object untouched rather than rebuilding it", () => {
+    // Cheap to assert and it pins the intent: nothing happened, so nothing changed.
+    const state = add(emptyHistory(), typed(0, "a"), 1000);
+    expect(addNothing(state, 2000)).toBe(state);
+  });
+
+  it("does not interrupt a typing run either side of it", () => {
+    // A dead keypress in the middle of a word must not split the word's undo step — that
+    // would trade a visible bug for a subtler one.
+    let state = emptyHistory();
+    state = add(state, typed(0, "h"), 1000);
+    state = addNothing(state, 1020);
+    state = add(state, typed(1, "i"), 1040);
+
+    expect(state.done).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Went after M6's mobile bullet. Found that the aggressive case is reachable after all — and then found a **data-loss bug that had been shipping since M3**, in a claim nobody expected to fail.

## Gboard's mechanism is drivable

`Input.imeSetComposition` accepts `replacementStart`/`replacementEnd`. That **is** Android word-level replacement — a composition that replaces an existing range rather than inserting at the caret — not an approximation of it. Same argument that made #89 worth doing: nothing faked at the DOM level.

Three specs, Chromium and mobile Chrome:

- replacing `teh` with `the` reconciles correctly, model and DOM in step, no stray `insertCompositionText`
- **a replaced word is one undo step** — two DOM edits, one history entry
- a replacement range deliberately stretched across a mention **cannot destroy the chip**. Not because the engine checks: Chromium clamps its own replacement range at the `contenteditable="false"` boundary and refuses to compose across it, so the mention keeps its `value`. Inherited protection, the same pattern as ADR 0005's arrow traversal and whole-chip delete.

What still needs a device is Gboard's *policy* — when it fires, how much it takes — not the mechanism.

## The actual bug

Giving [ADR 0008](../blob/feat/engine-m6-replacement/packages/engine/docs/adr/0008-undo-granularity-is-word-based.md) its first browser coverage turned up that **a keypress which changed nothing was recorded as an undo step.**

ADR 0004 reads a collapsed browser range as *"delete nothing — that is information, not an omission"*, and Chromium and Firefox **do** fire `deleteContentForward` with one whenever there is nothing ahead of the caret. So the engine built a zero-step transaction, and `record` stored it:

```
type "abc"           depth 2
press Delete x4      depth 6      ← four entries, nothing changed
```

Three costs, in increasing order of seriousness:

1. **A dead undo press** per dead keystroke — ⌘Z that visibly does nothing.
2. **A split typing run.** A no-op mid-word ended the group, so `hi` + dead-Delete + `gh` was two undo steps. Directly against ADR 0008's central claim. I hadn't predicted this one; the test found it.
3. **The redo branch.** `record` clears it, so an undone edit became unrecoverable — type, undo, press Delete at the end, press redo, and the text is **gone for good**. That is data loss, not an annoyance.

The fix is one guard: an entry with no `undoSteps` and no `redoSteps` is not an edit and is not recorded.

**WebKit never showed the keyboard route** — it fires no `beforeinput` when there is nothing to delete. It reaches the same bug through a **selection-only transaction**, which is an ordinary thing for a consumer or an M7 adapter to dispatch to move the caret. One guard covers both, and the spec asserts the history is *unchanged* rather than that it grew by a specific amount, so an exact-count assertion can't pass on WebKit for the wrong reason.

**Why this survived since M3:** the engine was right twice — right that a collapsed range means delete nothing, and right to build a transaction for it. The mistake was treating *a transaction happened* as *an edit happened*. Nothing had ever said those were different events.

## Verification

Confirmed red before fixing, at both levels:

- **4 unit tests** fail without the guard
- **11 e2e specs** fail across the three engines, including the redo test on WebKit via the selection route

Then: 440 unit tests (was 436), **290 e2e passing / 30 skipped** (was 248/24), typecheck and e2e typecheck clean. The 6 new skips are the 3 composition specs on Firefox and WebKit, which have no CDP equivalent.

## Also worth flagging

This is an argument for **discharging *Unverified* sections even when you expect them to pass**. ADR 0008's rule was thoroughly unit-tested and correct; the bug was in what the history did with a transaction the rule never contemplated. No amount of testing the rule would have found it.

## Test by hand

Quick, and satisfying, in **Chrome or Firefox** (`pnpm --filter @mentis/engine dev`):

1. Type `abc`. Press **Delete** four times — nothing happens, correctly. Now press **⌘Z** once: `abc` should vanish. Before this it took five presses, the first four doing nothing.
2. Type `abc`, press **⌘Z** (text goes), press **Delete** once, then **⌘⇧Z**. `abc` should come back. Before, it was unrecoverable.
3. Type `hi`, press **Delete**, type `gh`, then **⌘Z** once — all four characters should go as one word.

Nothing to check in Safari; it never fired the event.

## What's left in M6

**iOS autocorrect and dictation**, which arrive as `insertReplacementText` rather than as a composition and have no automatable route — CDP has no spellcheck-correction command, and synthesising the event would only check the engine against our own guess at its shape. That plus **real Gboard on a real device** is the remainder, and both want a human with a phone rather than another spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
