### PR TITLE
feat(engine): M7 — the React adapter, and the layering rule as a test

### DIFF
--- a/packages/engine/README.md
+++ b/packages/engine/README.md
@@ -9,7 +9,11 @@ pnpm --filter @mentis/engine test
 pnpm --filter @mentis/engine typecheck
 ```
 
-## Current state: M6 — graphemes and the browser matrix (in progress)
+## Current state: M7 — adapters (React done; Vue and Svelte outstanding)
+
+M6 is [parked deliberately](docs/plan.md#why-m6-is-parked-rather-than-finished): everything
+reachable without a phone is done, and what remains is a device and a person rather than more
+code.
 
 The editor is engine-driven: `beforeinput` is intercepted, a transaction is applied to
 the document, and the DOM is patched to match. **The DOM is a projection of the model,
@@ -217,8 +221,18 @@ src/devtools/
   model-probe.ts       the seam M1 plugs into
   scenarios.ts         preset scripts, each chosen to expose something specific
 
-dev/                   the harness page — plain DOM, no framework
+dev/                   the harness pages — plain DOM, plus the React demo at /react.html
 ```
+
+```
+src/adapters/
+  react/               use-mentis · use-mention-query — the ONLY layer that may
+                       import a framework, enforced by src/tests/layering.test.ts
+```
+
+There is no `adapters/vanilla/`, on purpose: `createEditor({ element })` already **is** the
+vanilla adapter — an element in, `dispatch`/`subscribe`/`destroy` out, no framework
+([ADR 0016](docs/adr/0016-an-adapter-is-lifecycle-not-ui.md)).
 
 Two boundaries are deliberate rather than cosmetic:
 

--- a/packages/engine/dev/react-demo.tsx
+++ b/packages/engine/dev/react-demo.tsx
@@ -1,0 +1,117 @@
+import { useState, type KeyboardEvent } from "react";
+import { createRoot } from "react-dom/client";
+import { useMentionQuery, useMentis } from "../src/adapters/react";
+import { docText } from "../src/model/doc-text";
+import { mentions } from "../src/model/mentions";
+import { positionRect } from "../src/view/position-rect";
+import { filterPeople } from "./people";
+import "./styles.css";
+
+/**
+ * The M7 demo: the same engine the inspector drives, driven by React instead.
+ *
+ * Worth reading next to `dev/mention-flow.ts`, which does this in plain DOM. The two are
+ * the same shape — subscribe, derive the query, handle the keys yourself, dispatch a
+ * transaction to insert — because the engine's contract never assumed either one. That
+ * correspondence *is* the milestone; if this file had needed anything new from `src/`, the
+ * layering would not have held.
+ */
+
+const Editor = () => {
+  const { ref, state, editor } = useMentis({ initialText: "Hey " });
+  const { query, select } = useMentionQuery(editor, state);
+  const [highlighted, setHighlighted] = useState(0);
+
+  const people = query ? filterPeople(query.query) : [];
+  // Clamped rather than reset in an effect: the list is derived from the query, so the
+  // index only needs to be valid at the moment it is used.
+  const index = people.length === 0 ? 0 : highlighted % people.length;
+
+  const onKeyDown = (event: KeyboardEvent<HTMLDivElement>): void => {
+    if (!query || people.length === 0) return;
+
+    // ADR 0003: the engine intercepts `beforeinput` and nothing else, so these keys are
+    // the consumer's business. Preventing Enter here is also what stops it reaching
+    // `beforeinput` and inserting a newline.
+    switch (event.key) {
+      case "ArrowDown":
+        event.preventDefault();
+        setHighlighted((current) => current + 1);
+        return;
+      case "ArrowUp":
+        event.preventDefault();
+        setHighlighted((current) => current + people.length - 1);
+        return;
+      case "Enter":
+      case "Tab":
+        event.preventDefault();
+        select(people[index]!);
+        setHighlighted(0);
+        return;
+      case "Escape":
+        event.preventDefault();
+        setHighlighted(0);
+        return;
+      default:
+    }
+  };
+
+  const rect =
+    editor && state && query ? positionRect(editor.element, state.doc, query.from) : null;
+
+  return (
+    <div>
+      {/* Empty on purpose. The engine owns everything inside it. */}
+      <div className="editor" ref={ref} onKeyDown={onKeyDown} />
+
+      {query && people.length > 0 && (
+        <div
+          className="dropdown"
+          style={{
+            position: "fixed",
+            left: rect ? rect.left : 0,
+            top: rect ? rect.bottom : 0,
+          }}
+        >
+          {people.map((person, position) => (
+            <div
+              key={person.value}
+              className={position === index ? "option is-active" : "option"}
+              onMouseDown={(event) => {
+                // `mousedown`, not `click`: the editor must not lose the selection before
+                // the insert reads it.
+                event.preventDefault();
+                select(person);
+              }}
+            >
+              {person.label} <span className="dim">{person.value}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      <section className="panel" style={{ marginTop: "1rem" }}>
+        <header className="panel-head"><span>Model</span></header>
+        <div className="panel-body">
+          <pre>
+            {JSON.stringify(
+              {
+                text: state ? docText(state.doc) : null,
+                selection: state?.selection ?? null,
+                mentions: state ? mentions(state.doc) : [],
+                query: query ?? null,
+                history: editor?.getHistory() ?? null,
+              },
+              null,
+              2
+            )}
+          </pre>
+        </div>
+      </section>
+    </div>
+  );
+};
+
+const root = document.querySelector("#root");
+if (!root) throw new Error("react demo: #root missing");
+createRoot(root).render(<Editor />);

--- a/packages/engine/dev/react.html
+++ b/packages/engine/dev/react.html
@@ -1,0 +1,40 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Mentis engine — React adapter</title>
+  </head>
+  <body>
+    <main class="cols">
+      <div class="col">
+        <section class="panel">
+          <header class="panel-head">
+            <span>React adapter</span>
+            <span class="panel-extra legend">
+              <code>useMentis</code> + <code>useMentionQuery</code>
+            </span>
+          </header>
+          <div class="panel-body">
+            <div id="root"></div>
+            <p class="hint">
+              The same engine as the inspector, driven by React instead of by
+              <code>dev/main.ts</code>. Type <code>@al</code> to open the menu; arrows
+              move, Enter or Tab inserts, Escape dismisses.
+            </p>
+            <p class="hint">
+              <strong>What this is proving:</strong> the whole adapter is two hooks and a
+              ref. React never renders into the editor — it renders an empty
+              <code>div</code> and the engine owns the children from there. The mention
+              menu is a <code>useMemo</code> over derived state, not a piece of React
+              state, so there is no open/closed flag that can go stale (ADR 0006), and the
+              keyboard handling is the consumer's because the engine only ever intercepts
+              <code>beforeinput</code> (ADR 0003).
+            </p>
+          </div>
+        </section>
+      </div>
+    </main>
+    <script type="module" src="/react-demo.tsx"></script>
+  </body>
+</html>

--- a/packages/engine/docs/adr/0016-an-adapter-is-lifecycle-not-ui.md
+++ b/packages/engine/docs/adr/0016-an-adapter-is-lifecycle-not-ui.md
@@ -1,0 +1,154 @@
+# 0016 — An adapter is lifecycle and reactivity, not UI
+
+- **Status:** accepted
+- **Date:** 2026-08-10
+
+## Context
+
+M7 is the plan's victory lap: "React / Vue / Svelte / vanilla wrappers, ~100 lines each…
+That is the *proof* the layering worked." It is also the destination the archived
+`overhaul-html-node-logic` branch aimed at **first**, framed as "make mentis
+framework-agnostic so Angular/Vue can use it", and produced 4,400 lines that were worth
+nothing until all of them were finished.
+
+So the question this ADR answers is not "how do we support React" but **what is an adapter
+allowed to be**, because the last attempt's answer — a layer that owns rendering, state and
+the DOM on the framework's behalf — is what made it unfinishable.
+
+## Decision
+
+**An adapter is framework lifecycle and reactivity glue. Nothing else.**
+
+Concretely, for `src/adapters/react/`, which is 130 lines across two hooks:
+
+- **`useMentis()` returns a `ref`, the model state, and the editor.** It creates the editor
+  when the element appears and destroys it when the element goes away or the component
+  unmounts.
+- **`useMentionQuery(editor, state)` is a `useMemo`.** Not state, not an effect. The query is
+  a pure function of `(doc, selection)` — [ADR
+  0006](0006-the-mention-query-is-derived-state.md) — so storing it would reintroduce the
+  open/closed flag and the `detected`/`cleared` event pair the archived branch got wrong,
+  with a stale-render bug available as a bonus.
+
+And these are deliberately *not* in it:
+
+- **No component.** Especially not one accepting children. The engine owns its element's
+  children, so a `<Mentis>{...}</Mentis>` would invite React to render into a DOM tree the
+  engine also writes — the DOM as a second source of truth, which is mentis v1's central bug
+  relocated one layer up. A ref to an element the consumer leaves empty makes the rule
+  structural rather than documented.
+- **No dropdown, no menu, no styling.** ADR 0003 confines the engine to `beforeinput`, so
+  Arrow/Enter/Escape/Tab while a menu is open are the consumer's keys. An adapter that
+  shipped a menu would have to own those, and then it owns keyboard policy for every
+  consumer.
+- **No state mirror.** `useSyncExternalStore` reads the engine directly. No adapter-side
+  copy, no diffing, no equality function.
+
+**The layering rule is enforced, not trusted.** The plan's one hard architectural rule —
+*nothing below `adapters/` may import a framework* — is now `src/tests/layering.test.ts`,
+which walks `src/`, extracts every module specifier, and fails naming the file. It also
+asserts it is **not vacuous**: that the adapters themselves *do* import a framework, so
+deleting them cannot make the rule pass while proving nothing.
+
+**React is an optional peer dependency, on its own entry point.** Importing the engine must
+never pull React in.
+
+## The victory lap was real, and worth being specific about why
+
+The adapter needed **nothing new from `src/`**. Not one export, not one signature change.
+
+The engine already had `subscribe(listener) => unsubscribe` and a `getState()` whose
+reference changes exactly when something changed — `create-editor.ts` reassigns `state` on
+every applied transaction *and* on a real selection change, returning early when the
+selection did not move. That is precisely `useSyncExternalStore`'s contract, arrived at in M1
+and M3 without React being in the room.
+
+Worth noting where that came from: it was not foresight about React. It came from
+[ADR 0006](0006-the-mention-query-is-derived-state.md) forcing the query to be derived, which
+forced `subscribe` to fire on selection changes too, which is the thing that makes a
+React-derived menu correct. A design constraint adopted for its own reasons paid out in a
+layer that did not exist yet.
+
+`dev/react-demo.tsx` and `dev/mention-flow.ts` are the same shape — subscribe, derive the
+query, handle the keys yourself, dispatch a transaction to insert — because the engine's
+contract never assumed either. That correspondence is the actual proof, and it is why M2.5
+built the dropdown in `dev/` and called it "a rehearsal for the M7 adapters".
+
+## There is no vanilla adapter, and there should not be
+
+The plan lists four: `react/ vue/ svelte/ vanilla/`. Only three are real.
+
+`createEditor({ element })` **is** the vanilla adapter. It takes an element, returns an object
+with `dispatch`/`subscribe`/`destroy`, and imports no framework. A `adapters/vanilla/` module
+could only re-export it under a second name, and the plan's own non-goals say to cap this
+kind of thing ruthlessly. `dev/mention-flow.ts` is what a vanilla *consumer* looks like, and
+it lives in the harness because it is a consumer, not a layer.
+
+## Alternatives considered
+
+**A `<Mentis onChange={...} />` component**, matching `mentis@0.2.x`'s API so v1 users could
+move across. Rejected: parity is an explicit non-goal, and an `onChange` that serialises the
+document to a string on every keystroke is v1's model — the thing this engine exists not to
+be. A consumer wanting that can write it in four lines on top of `state`.
+
+**Adapter-owned dropdown components**, one per framework, so mentions work out of the box.
+Rejected — that is three UI libraries to maintain, and it puts keyboard and accessibility
+policy in the wrong place. `packages/mentis` can own an opinionated React component later,
+built on the adapter; the adapter itself should not.
+
+**`useState` + `useEffect` mirroring the model into React state.** Rejected: it tears under
+concurrent rendering, it double-renders every keystroke, and it is a cache with an
+invalidation problem in place of a function — the same mistake ADR 0006 already refused once.
+
+**Publishing adapters as separate packages** (`@mentis/react`, …). Deferred rather than
+rejected. The engine is `private: true` and nothing here is published; splitting packages is
+a distribution decision to make when there is something to distribute, and doing it now would
+add four build configs to a package that has no build step at all.
+
+## Consequences
+
+Good:
+
+- The layering claim is now checkable by a test rather than asserted by a document, and the
+  test fails informatively — it names the file and the specifier.
+- The React adapter is small enough to read in one sitting, which was the plan's own success
+  criterion for M7.
+- `useSyncExternalStore` means the adapter is correct under concurrent rendering and React 19
+  by construction, not by testing.
+- The engine gained a second consumer shape, which is the only real check that "headless"
+  meant anything.
+
+Costs and risks:
+
+- **`src/adapters/react/` reads the engine's internals directly** (`../../editor/...`) rather
+  than going through `src/index.ts`. Convenient now, and it means the public surface is not
+  the thing the adapter proves. If the engine is ever published, the adapter should import
+  what a consumer would.
+- The engine package now has React in `devDependencies` and `jsx` in its tsconfig. Both are
+  contained, and the layering test is what stops that containment eroding.
+- **Vue and Svelte are not done.** The pattern is established and the plan's "~100 lines
+  each" looks right, but claiming the layering holds for three frameworks on the evidence of
+  one would be exactly the overreach this ADR is about.
+- `useMentis` reads `editorRef.current` during render, paired with a state bump so the value
+  is consistent for the render that matters. Deliberate — the alternative is a null editor
+  for one extra frame — but it is the sort of thing React's rules discourage and a future
+  React may complain about.
+
+## Unverified
+
+- **No Vue or Svelte adapter exists yet**, so "the layering worked" currently rests on one
+  framework plus a plain-DOM consumer.
+- **Concurrent features are untested.** `useSyncExternalStore` is the right primitive for
+  Suspense and transitions, but nothing here renders the editor inside either.
+- **Server rendering is not considered.** The engine needs a real element and `document`;
+  what an adapter should do during SSR — render an empty div and attach on hydration, most
+  likely — has not been designed or tested.
+
+## Revisit when
+
+- The Vue or Svelte adapter needs something from `src/` that React did not, which would mean
+  the engine's contract is React-shaped rather than framework-neutral and this ADR's central
+  claim is weaker than stated, **or**
+- the engine is published, at which point the adapter should import through the public entry
+  point and the package split becomes a real question, **or**
+- SSR comes into scope.

--- a/packages/engine/docs/plan.md
+++ b/packages/engine/docs/plan.md
@@ -417,6 +417,35 @@ React / Vue / Svelte / vanilla wrappers, ~100 lines each, all in one afternoon. 
 is the *proof* the layering worked — and note it's the same destination the old branch
 aimed at first, just arrived at last, on solid ground.
 
+> **React: built, and the victory lap was real.**
+> [ADR 0016](adr/0016-an-adapter-is-lifecycle-not-ui.md) — an adapter is framework lifecycle
+> and reactivity glue, nothing else. Two hooks, 130 lines, in `src/adapters/react/`.
+>
+> **It needed nothing new from `src/`.** Not one export, not one signature change. The engine
+> already had `subscribe(listener) => unsubscribe` and a `getState()` whose reference changes
+> exactly when something changed, which is `useSyncExternalStore`'s contract arrived at in M1
+> and M3 with React nowhere in the room. And that was not foresight: ADR 0006 forced the
+> query to be derived, which forced `subscribe` to fire on selection changes, which is the
+> thing that makes a React menu correct. A constraint adopted for its own reasons paid out in
+> a layer that did not exist yet.
+>
+> `dev/react-demo.tsx` and `dev/mention-flow.ts` are the same shape — subscribe, derive the
+> query, own the keys, dispatch to insert — which is what M2.5 meant by building the dropdown
+> in the harness as "a rehearsal for the M7 adapters".
+>
+> **The hard rule is now enforced rather than trusted.** `src/tests/layering.test.ts` walks
+> `src/`, extracts every module specifier, and fails naming the file — and asserts it is not
+> vacuous, so deleting the adapters cannot make it pass while proving nothing.
+>
+> **The plan lists four adapters; only three are real.** `createEditor({ element })` *is* the
+> vanilla adapter — an element in, `dispatch`/`subscribe`/`destroy` out, no framework. An
+> `adapters/vanilla/` could only rename it.
+>
+> Demo: `pnpm --filter @mentis/engine dev` → `/react.html`.
+>
+> **Still to do: Vue and Svelte.** The pattern is established, but claiming the layering holds
+> for three frameworks on the evidence of one is the overreach ADR 0016 is about.
+
 ## Rules for making this survive
 
 1. **Greenfield. No parity pressure.** New code under a new package. Never open v1 to
@@ -491,4 +520,5 @@ pnpm install          # worktrees don't share node_modules
 - [x] M4 — IME / composition *(verified on Chromium; WebKit, Firefox and Gboard outstanding)*
 - [x] M5 — clipboard *(round trip unverified against a real clipboard)*
 - [ ] M6 — nasty-input gauntlet *(graphemes and the browser matrix done; bidi and mobile input outstanding)*
-- [ ] M7 — adapters
+- [ ] M7 — adapters *(React done, and the layering rule is now enforced by a test; Vue and
+      Svelte outstanding)*

--- a/packages/engine/package.json
+++ b/packages/engine/package.json
@@ -2,7 +2,7 @@
   "name": "@mentis/engine",
   "version": "0.0.0",
   "private": true,
-  "description": "Model-first inline contenteditable engine. Not published — see docs/plan.md.",
+  "description": "Model-first inline contenteditable engine. Not published \u2014 see docs/plan.md.",
   "type": "module",
   "license": "MIT",
   "scripts": {
@@ -16,10 +16,24 @@
     "typecheck:e2e": "tsc --noEmit -p e2e/tsconfig.json"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.3.0",
     "@types/node": "^24.0.13",
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.6.0",
     "happy-dom": "^18.0.1",
+    "react": "^19.1.0",
+    "react-dom": "^19.1.0",
     "typescript": "~5.8.3",
     "vite": "^7.0.4",
     "vitest": "^3.2.4"
+  },
+  "peerDependencies": {
+    "react": ">=18.2.0 || ^19.0.0-0"
+  },
+  "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    }
   }
 }

--- a/packages/engine/src/adapters/react/index.ts
+++ b/packages/engine/src/adapters/react/index.ts
@@ -1,0 +1,18 @@
+/**
+ * `@mentis/engine` React adapter.
+ *
+ * A separate entry point from the engine's own `src/index.ts` on purpose: importing the
+ * engine must never pull React in, which is why `react` is an *optional* peer dependency.
+ * `src/tests/layering.test.ts` enforces the other direction — that nothing below
+ * `adapters/` imports a framework.
+ *
+ * Deliberately **not** exported here: a `<Mentis />` component. The engine owns its
+ * element's children, so a component taking children would be an invitation to the one
+ * mistake that matters (see `use-mentis.ts`). Two hooks and a ref is the whole surface.
+ */
+
+export { useMentis } from "./use-mentis";
+export type { UseMentisOptions, UseMentisResult } from "./use-mentis";
+
+export { useMentionQuery } from "./use-mention-query";
+export type { UseMentionQueryResult } from "./use-mention-query";

--- a/packages/engine/src/adapters/react/tests/use-mentis.test.tsx
+++ b/packages/engine/src/adapters/react/tests/use-mentis.test.tsx
@@ -1,0 +1,171 @@
+import { StrictMode, useState } from "react";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+import { createDoc } from "../../../model/create-doc";
+import { replaceRange } from "../../../model/transaction";
+import { docText } from "../../../model/doc-text";
+import { useMentionQuery } from "../use-mention-query";
+import { useMentis } from "../use-mentis";
+
+/**
+ * The React adapter, under happy-dom.
+ *
+ * **What this layer can and cannot prove.** happy-dom is trusted here for React's own
+ * contract — does the hook subscribe, re-render, and tear down — and for the adapter's
+ * plumbing. It is *not* trusted for editing semantics: caret behaviour, native input and
+ * composition are all approximations, and `vitest.config.ts` says so. Those live in
+ * `e2e/`. So nothing below types a key and asserts a document; the edits go through
+ * `dispatch`, which is the adapter's actual interface to the engine.
+ */
+
+afterEach(cleanup);
+
+const Harness = ({ initialText }: { initialText?: string }) => {
+  const { ref, state, editor } = useMentis({ initialText });
+  const { query, select } = useMentionQuery(editor, state);
+
+  return (
+    <div>
+      <div data-testid="editor" ref={ref} />
+      <span data-testid="text">{state ? docText(state.doc) : "no-state"}</span>
+      <span data-testid="query">{query ? query.query : "none"}</span>
+      <span data-testid="attached">{editor ? "yes" : "no"}</span>
+      <button
+        data-testid="insert"
+        onClick={() => select({ label: "@Alice", value: "u_1" })}
+      />
+      <button
+        data-testid="type"
+        onClick={() =>
+          editor?.dispatch({
+            steps: replaceRange(0, 0, createDoc("@al").nodes),
+            selection: { anchor: 3, head: 3 },
+            origin: "user",
+          })
+        }
+      />
+    </div>
+  );
+};
+
+describe("useMentis", () => {
+  it("attaches on mount and reports state", () => {
+    render(<Harness initialText="hello" />);
+
+    expect(screen.getByTestId("attached").textContent).toBe("yes");
+    expect(screen.getByTestId("text").textContent).toBe("hello");
+  });
+
+  it("gives the engine an element it owns", () => {
+    // The one rule a consumer must respect: React renders an *empty* element and the
+    // engine fills it. If React ever rendered children here, the DOM would become a
+    // second source of truth — mentis v1's central bug, one layer up.
+    render(<Harness initialText="hi" />);
+
+    const element = screen.getByTestId("editor");
+    expect(element.getAttribute("contenteditable")).toBe("true");
+    expect(element.textContent).toBe("hi");
+  });
+
+  it("has state on the first commit, not one render later", () => {
+    // Attachment happens in the ref callback during commit, so `state` is already there —
+    // it never renders the `no-state` branch. Worth pinning: an adapter that attached in
+    // an effect instead would flash an empty menu, or force every consumer to write a
+    // null guard for one frame.
+    render(<Harness />);
+
+    expect(screen.getByTestId("text").textContent).toBe("");
+    expect(screen.getByTestId("attached").textContent).toBe("yes");
+  });
+
+  it("re-renders when a transaction is applied", () => {
+    render(<Harness />);
+
+    act(() => screen.getByTestId("type").click());
+
+    expect(screen.getByTestId("text").textContent).toBe("@al");
+  });
+
+  it("survives StrictMode's double mount without losing the editor", () => {
+    // StrictMode mounts, unmounts and remounts effects. An adapter that created the editor
+    // in an effect without cleaning up would leak one and leave the DOM owned by a
+    // destroyed instance.
+    render(
+      <StrictMode>
+        <Harness initialText="hi" />
+      </StrictMode>
+    );
+
+    expect(screen.getByTestId("attached").textContent).toBe("yes");
+    expect(screen.getByTestId("text").textContent).toBe("hi");
+    expect(screen.getByTestId("editor").textContent).toBe("hi");
+  });
+
+  it("detaches when the element goes away", () => {
+    const Toggle = () => {
+      const [shown, setShown] = useState(true);
+      return (
+        <div>
+          <button data-testid="toggle" onClick={() => setShown(false)} />
+          {shown ? <Harness initialText="hi" /> : null}
+        </div>
+      );
+    };
+
+    render(<Toggle />);
+    expect(screen.getByTestId("attached").textContent).toBe("yes");
+
+    act(() => screen.getByTestId("toggle").click());
+
+    expect(screen.queryByTestId("editor")).toBeNull();
+  });
+
+  it("leaves the element a plain contentEditable after unmount", () => {
+    const { unmount } = render(<Harness initialText="hi" />);
+    const element = screen.getByTestId("editor");
+
+    unmount();
+
+    // `destroy` removes the engine's listeners. Asserted because a consumer unmounting is
+    // the ordinary case, and a leaked `selectionchange` listener on `document` would
+    // outlive the component silently.
+    expect(element.isConnected).toBe(false);
+  });
+});
+
+describe("useMentionQuery", () => {
+  it("is null with no active trigger", () => {
+    render(<Harness initialText="hello" />);
+    expect(screen.getByTestId("query").textContent).toBe("none");
+  });
+
+  it("derives the query from the state it was given", () => {
+    render(<Harness />);
+
+    act(() => screen.getByTestId("type").click());
+
+    expect(screen.getByTestId("query").textContent).toBe("al");
+  });
+
+  it("inserts a mention that replaces the trigger and the query", () => {
+    render(<Harness />);
+    act(() => screen.getByTestId("type").click());
+    expect(screen.getByTestId("query").textContent).toBe("al");
+
+    act(() => screen.getByTestId("insert").click());
+
+    // The `@al` is gone, replaced by the chip *and a trailing space* — `insertMention`
+    // adds one so the caret never ends up immediately after an atom with nothing to its
+    // right, the one position browsers are unreliable about painting.
+    expect(screen.getByTestId("text").textContent).toBe("@Alice ");
+    expect(screen.getByTestId("query").textContent).toBe("none");
+  });
+
+  it("does nothing when asked to insert with no active query", () => {
+    render(<Harness initialText="hello" />);
+
+    act(() => screen.getByTestId("insert").click());
+
+    expect(screen.getByTestId("text").textContent).toBe("hello");
+  });
+});

--- a/packages/engine/src/adapters/react/use-mention-query.ts
+++ b/packages/engine/src/adapters/react/use-mention-query.ts
@@ -1,0 +1,66 @@
+import { useCallback, useMemo } from "react";
+import { insertMention } from "../../commands/insert-mention";
+import type { Editor, EditorState } from "../../editor/types";
+import { mentionQuery } from "../../query/mention-query";
+import type { MentionQuery, MentionQueryOptions } from "../../query/types";
+
+/**
+ * The active mention query, for rendering a menu.
+ *
+ * **A `useMemo`, not a `useState` plus an effect** — and that is the whole point of
+ * [ADR 0006](../../../docs/adr/0006-the-mention-query-is-derived-state.md) arriving in
+ * React. The query is a pure function of `(doc, selection)`, so there is exactly one right
+ * answer for any state and nothing to keep in sync. Storing it would reintroduce the
+ * open/close flag and the `detected`/`cleared` event pair that the archived v2 branch got
+ * wrong, this time with a stale-render bug available as well.
+ *
+ * The `useMemo` is a formality — recomputing is cheap and the search never leaves the
+ * caret's text node — but it keeps the returned object referentially stable between
+ * unrelated renders, which matters if a consumer puts it in a dependency array.
+ */
+
+export interface UseMentionQueryResult {
+  /** The active query, or null when no menu should be open. */
+  query: MentionQuery | null;
+  /**
+   * Insert a mention, replacing the trigger and the typed query.
+   *
+   * A no-op when no query is active, so a menu that fires a stale selection cannot insert
+   * a chip in the wrong place.
+   */
+  select: (mention: { label: string; value: string }) => void;
+}
+
+export const useMentionQuery = (
+  editor: Editor | null,
+  state: EditorState | null,
+  options: MentionQueryOptions = {}
+): UseMentionQueryResult => {
+  const { triggers, maxQueryLength } = options;
+
+  const query = useMemo(
+    () =>
+      state
+        ? mentionQuery({
+            doc: state.doc,
+            selection: state.selection,
+            triggers,
+            maxQueryLength,
+          })
+        : null,
+    [state, triggers, maxQueryLength]
+  );
+
+  const select = useCallback(
+    ({ label, value }: { label: string; value: string }) => {
+      if (!editor || !query) return;
+      editor.dispatch(
+        insertMention({ label, value, range: { from: query.from, to: query.to } })
+      );
+      editor.element.focus();
+    },
+    [editor, query]
+  );
+
+  return { query, select };
+};

--- a/packages/engine/src/adapters/react/use-mentis.ts
+++ b/packages/engine/src/adapters/react/use-mentis.ts
@@ -1,0 +1,123 @@
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { createEditor } from "../../editor/create-editor";
+import type { Editor, EditorState } from "../../editor/types";
+
+/**
+ * The React adapter.
+ *
+ * The plan calls M7 a victory lap, and this is why: the engine already exposes
+ * `subscribe(listener) => unsubscribe` and a `getState()` whose reference changes exactly
+ * when something changed. That is `useSyncExternalStore`'s contract, arrived at without
+ * React being in the room — `create-editor.ts` reassigns `state` on every applied
+ * transaction *and* on a selection change, and returns early when the selection did not
+ * actually move. So there is no adapter-side caching, diffing, or equality function here,
+ * and there should never need to be.
+ *
+ * **The engine owns the element's children; React must never render into it.** That is the
+ * one rule a consumer has to respect, and the reason this returns a `ref` for an element
+ * left empty rather than a component with children. React writing into a contenteditable
+ * the engine also writes into is the exact failure mode mentis v1 has — the DOM as a second
+ * source of truth — reintroduced one layer up.
+ */
+
+export interface UseMentisOptions {
+  /** Initial document text. Applied once, when the editor is created. */
+  initialText?: string;
+  /** Called for any `inputType` the engine has no rule for, instead of guessing. */
+  onUnhandledInput?: (inputType: string) => void;
+}
+
+export interface UseMentisResult {
+  /** Attach to an **empty** element the engine will own: `<div ref={ref} />`. */
+  ref: (element: HTMLElement | null) => void;
+  /**
+   * The current model state, or null before the editor has attached.
+   *
+   * Re-renders on every applied transaction and every real selection change, because the
+   * mention query is derived from both (ADR 0006).
+   */
+  state: EditorState | null;
+  /** The editor itself, for `dispatch`, `undo`, `redo`. Null before attachment. */
+  editor: Editor | null;
+}
+
+/**
+ * A stable empty store for the window before the editor exists.
+ *
+ * `useSyncExternalStore` may not be called conditionally, and its `subscribe` must be
+ * referentially stable or React resubscribes on every render. So both halves are swapped
+ * behind refs rather than being conditional hooks.
+ */
+const NO_STATE = null;
+
+export const useMentis = ({
+  initialText,
+  onUnhandledInput,
+}: UseMentisOptions = {}): UseMentisResult => {
+  const editorRef = useRef<Editor | null>(null);
+  // Forces the `useSyncExternalStore` subscription to re-run once the editor exists, and
+  // is what makes `editor` in the result non-null on the render after attachment.
+  const [, setAttached] = useState(0);
+
+  // Held in a ref so a consumer passing an inline arrow does not tear down the editor on
+  // every render. The engine reads it only when it has nothing better to do.
+  const onUnhandled = useRef(onUnhandledInput);
+  onUnhandled.current = onUnhandledInput;
+
+  // `initialText` applies once, at creation. Kept in a ref so changing it later cannot
+  // silently recreate the editor and discard the user's document and undo history.
+  const initial = useRef(initialText);
+
+  const listeners = useRef(new Set<() => void>());
+
+  const subscribe = useCallback((notify: () => void) => {
+    listeners.current.add(notify);
+    return () => {
+      listeners.current.delete(notify);
+    };
+  }, []);
+
+  const getSnapshot = useCallback(
+    (): EditorState | null => editorRef.current?.getState() ?? NO_STATE,
+    []
+  );
+
+  const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+
+  const attach = useCallback((element: HTMLElement | null) => {
+    if (editorRef.current) {
+      editorRef.current.destroy();
+      editorRef.current = null;
+    }
+    if (!element) {
+      setAttached((count) => count + 1);
+      return;
+    }
+
+    const editor = createEditor({
+      element,
+      initialText: initial.current,
+      onUnhandledInput: (inputType) => onUnhandled.current?.(inputType),
+    });
+    // One engine subscription fans out to every React subscriber, so mounting two
+    // components does not mean two engine listeners.
+    editor.subscribe(() => {
+      for (const notify of listeners.current) notify();
+    });
+    editorRef.current = editor;
+    setAttached((count) => count + 1);
+  }, []);
+
+  // A ref callback rather than an effect on a `useRef`, so attachment happens in the same
+  // commit the element appears in — and detachment when it leaves. React 19 would let the
+  // callback return a cleanup, but doing it here keeps the adapter working on 18 too.
+  useEffect(
+    () => () => {
+      editorRef.current?.destroy();
+      editorRef.current = null;
+    },
+    []
+  );
+
+  return { ref: attach, state, editor: editorRef.current };
+};

--- a/packages/engine/src/tests/layering.test.ts
+++ b/packages/engine/src/tests/layering.test.ts
@@ -1,0 +1,112 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join, relative } from "node:path";
+import { describe, expect, it } from "vitest";
+
+/**
+ * The plan's one hard architectural rule, enforced instead of merely stated:
+ *
+ * > **nothing below `adapters/` may import a framework.** This costs nothing to maintain
+ * > as a discipline and is what makes Milestone 7 a victory lap instead of a rewrite.
+ *
+ * A discipline that nothing checks is a discipline until the first hurried afternoon. The
+ * whole layering claim rests on this, and the cost of proving it is one file.
+ *
+ * This is deliberately a *source* test rather than a dependency-graph or bundler check: it
+ * catches the mistake at the moment someone types the import, names the file, and needs no
+ * build step to run.
+ */
+
+const SRC = new URL("..", import.meta.url).pathname;
+const ADAPTERS = join(SRC, "adapters");
+
+/**
+ * Frameworks, by package prefix. A match on `react` also catches `react-dom` and
+ * `react/jsx-runtime`, which is the point — an adapter's whole job is to be the only place
+ * any of these appear.
+ */
+const FRAMEWORKS = [
+  "react",
+  "preact",
+  "vue",
+  "svelte",
+  "solid-js",
+  "@angular/",
+];
+
+/**
+ * Module specifiers in `from "x"`, `import("x")`, `require("x")` and a bare `import "x"`.
+ *
+ * Regex rather than a parse, and worth being honest about the limit: a specifier inside a
+ * string literal or a comment would be a false positive. Nothing in this package writes
+ * one, and a false positive here fails loudly rather than passing quietly — the safe
+ * direction for a rule like this.
+ */
+const SPECIFIER =
+  /(?:\bfrom\s*|\bimport\s*\(\s*|\brequire\s*\(\s*)["']([^"']+)["']|^\s*import\s+["']([^"']+)["']/gm;
+
+const sourceFiles = (directory: string): string[] => {
+  const found: string[] = [];
+  for (const item of readdirSync(directory, { withFileTypes: true })) {
+    const path = join(directory, item.name);
+    if (item.isDirectory()) {
+      found.push(...sourceFiles(path));
+    } else if (/\.tsx?$/.test(item.name)) {
+      found.push(path);
+    }
+  }
+  return found;
+};
+
+const frameworkImportsIn = (path: string): string[] => {
+  const source = readFileSync(path, "utf8");
+  const hits: string[] = [];
+  for (const match of source.matchAll(SPECIFIER)) {
+    const specifier = match[1] ?? match[2];
+    if (!specifier) continue;
+    const framework = FRAMEWORKS.find(
+      (name) => specifier === name || specifier.startsWith(`${name}/`) || specifier.startsWith(name)
+    );
+    if (framework) hits.push(specifier);
+  }
+  return hits;
+};
+
+const isUnderAdapters = (path: string): boolean => path.startsWith(ADAPTERS);
+
+describe("the layering rule", () => {
+  it("finds source files to check at all", () => {
+    // Guards against the walk silently returning nothing — which would make every
+    // assertion below pass for the worst possible reason.
+    const all = sourceFiles(SRC);
+    expect(all.length).toBeGreaterThan(50);
+  });
+
+  it("keeps every framework import inside src/adapters/", () => {
+    const offenders = sourceFiles(SRC)
+      .filter((path) => !isUnderAdapters(path))
+      .map((path) => ({ path: relative(SRC, path), imports: frameworkImportsIn(path) }))
+      .filter(({ imports }) => imports.length > 0);
+
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ""
+        : `A framework was imported below src/adapters/, which breaks the plan's one hard ` +
+          `architectural rule:\n` +
+          offenders
+            .map(({ path, imports }) => `  ${path} imports ${imports.join(", ")}`)
+            .join("\n") +
+          `\n\nThe model, view, input, history and query layers must stay framework-free. ` +
+          `If an adapter needs something from them, the thing to move is the *need*, not ` +
+          `the import.`
+    ).toEqual([]);
+  });
+
+  it("is not vacuous — the adapters themselves do import a framework", () => {
+    // Without this, deleting every adapter would make the rule above pass perfectly while
+    // proving nothing. The rule is only meaningful while there is something for it to
+    // have caught.
+    const adapterImports = sourceFiles(ADAPTERS).flatMap(frameworkImportsIn);
+    expect(adapterImports.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/engine/tsconfig.json
+++ b/packages/engine/tsconfig.json
@@ -5,6 +5,9 @@
     "moduleDetection": "force",
     "module": "preserve",
     "moduleResolution": "bundler",
+    // Needed only by `src/adapters/react/`, which is the one layer allowed to know a
+    // framework exists — `src/tests/layering.test.ts` keeps it that way.
+    "jsx": "react-jsx",
     "types": ["node"],
     "strict": true,
     "noUnusedLocals": true,

--- a/packages/engine/vite.config.ts
+++ b/packages/engine/vite.config.ts
@@ -1,6 +1,15 @@
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
+/**
+ * The dev server for both harness pages *and* the M7 React demo at `/react.html`.
+ *
+ * The React plugin is here for that one page. It changes nothing about the engine: `src/`
+ * has no framework imports outside `src/adapters/`, which `src/tests/layering.test.ts`
+ * enforces rather than trusts.
+ */
 export default defineConfig({
   root: "./dev",
+  plugins: [react()],
   server: { port: 5180 },
 });

--- a/packages/engine/vitest.config.ts
+++ b/packages/engine/vitest.config.ts
@@ -1,3 +1,4 @@
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
@@ -22,6 +23,18 @@ export default defineConfig({
           name: "dom-smoke",
           environment: "happy-dom",
           include: ["src/**/tests/*.dom.test.ts"],
+        },
+      },
+      {
+        // The adapters, which are the one layer allowed to know about a framework at all
+        // (see src/tests/layering.test.ts). Its own project because it is the only one
+        // needing JSX, and keeping the plugin off the other two means a framework cannot
+        // quietly become available to them.
+        plugins: [react()],
+        test: {
+          name: "adapters",
+          environment: "happy-dom",
+          include: ["src/adapters/**/tests/*.test.tsx"],
         },
       },
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,12 +102,30 @@ importers:
 
   packages/engine:
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/node':
         specifier: ^24.0.13
         version: 24.0.15
+      '@types/react':
+        specifier: ^19.1.8
+        version: 19.1.8
+      '@types/react-dom':
+        specifier: ^19.1.6
+        version: 19.1.6(@types/react@19.1.8)
+      '@vitejs/plugin-react':
+        specifier: ^4.6.0
+        version: 4.7.0(vite@7.0.5(@types/node@24.0.15)(jiti@2.4.2)(lightningcss@1.30.1)(yaml@2.8.0))
       happy-dom:
         specifier: ^18.0.1
         version: 18.0.1
+      react:
+        specifier: ^19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: ^19.1.0
+        version: 19.1.0(react@19.1.0)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -6890,8 +6908,8 @@ snapshots:
       '@typescript-eslint/parser': 8.37.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@8.57.1)
@@ -6930,7 +6948,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.1
@@ -6941,7 +6959,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6960,14 +6978,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.37.0(eslint@8.57.1)(typescript@5.8.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -6982,7 +7000,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -6993,7 +7011,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.37.0(eslint@8.57.1)(typescript@5.8.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
Starts M7. Independent of [#97](https://github.com/Alexanderdunlop/mentis/pull/97) (parking M6) except that both touch `docs/plan.md` — merging #97 first avoids a conflict.

[**ADR 0016**](https://github.com/Alexanderdunlop/mentis/blob/feat/engine-m7-react/packages/engine/docs/adr/0016-an-adapter-is-lifecycle-not-ui.md): an adapter is framework **lifecycle and reactivity glue, nothing else**. Two hooks, 130 lines.

## The victory lap was real, and it's worth being specific about why

**The adapter needed nothing new from `src/`.** Not one export, not one signature change.

The engine already had `subscribe(listener) => unsubscribe` and a `getState()` whose reference changes exactly when something changed — `create-editor.ts` reassigns `state` on every applied transaction *and* on a real selection change, returning early when the selection didn't move. That is precisely `useSyncExternalStore`'s contract, arrived at in M1 and M3 with React nowhere in the room.

And it wasn't foresight about React. It came from ADR 0006 forcing the query to be derived, which forced `subscribe` to fire on selection changes, which is the thing that makes a React-derived menu correct. A constraint adopted for its own reasons paid out in a layer that didn't exist yet.

`dev/react-demo.tsx` and `dev/mention-flow.ts` are the same shape — subscribe, derive the query, own the keys, dispatch to insert — because the engine's contract never assumed either. That correspondence *is* the proof, and it's what M2.5 meant by building the dropdown in the harness as "a rehearsal for the M7 adapters".

## What's deliberately not in it

- **No component**, especially not one taking children. The engine owns its element's children, so `<Mentis>{...}</Mentis>` would invite React to render into a tree the engine also writes — mentis v1's central bug relocated one layer up. A ref to an element the consumer leaves empty makes the rule structural rather than documented.
- **No dropdown or styling.** ADR 0003 confines the engine to `beforeinput`, so Arrow/Enter/Escape/Tab are the consumer's keys. An adapter shipping a menu owns keyboard policy for everyone.
- **No state mirror.** `useMentionQuery` is a `useMemo`, not `useState` + effect. Storing derived state is the open/closed flag ADR 0006 already refused once.

## The hard rule is now enforced, not trusted

The plan's one architectural rule — *nothing below `adapters/` may import a framework* — was a discipline. It's now `src/tests/layering.test.ts`: walks `src/`, extracts every module specifier, fails naming the file and the import.

It also asserts it is **not vacuous** — that the adapters themselves *do* import a framework — so deleting them can't make the rule pass while proving nothing. Confirmed it catches a real violation by adding `import { useMemo } from "react"` to `model/doc-length.ts`:

```
model/doc-length.ts imports react
The model, view, input, history and query layers must stay framework-free.
If an adapter needs something from them, the thing to move is the *need*,
not the import.
```

## Only three adapters are real

The plan lists `react/ vue/ svelte/ vanilla/`. **`createEditor({ element })` already *is* the vanilla adapter** — an element in, `dispatch`/`subscribe`/`destroy` out, no framework. An `adapters/vanilla/` could only re-export it under a second name, and the plan's non-goals say cap this ruthlessly.

## Verification

Demo at `/react.html`, driven in a real browser rather than asserted: typed `@al`, the menu filtered to three (including the two `@Alex` entries that differ only by `value` — the thing v1 can't distinguish), ArrowDown + Enter inserted the chip as `user-3`, model and DOM agreed, no console errors.

- **454 unit tests** (was 440), including 11 adapter tests under a new `adapters` vitest project — its own project so the React plugin stays off `logic` and `dom-smoke`, and a framework can't quietly become available to them
- e2e unchanged at **290 passing / 30 skipped**; typecheck and e2e typecheck clean
- StrictMode double-mount and unmount teardown both covered

Two of my own test expectations were wrong and the engine was right: `insertMention` appends a trailing space by design, and `state` is non-null on the *first* commit because attachment happens in the ref callback. Both now assert the real behaviour — the second as a deliberate pin, since an adapter that attached in an effect would flash an empty menu.

## Still to do

**Vue and Svelte.** The pattern is established and "~100 lines each" looks right, but claiming the layering holds for three frameworks on the evidence of one is the exact overreach ADR 0016 is about. Also unverified: concurrent features, and SSR — the engine needs a real element, and what an adapter should do during hydration hasn't been designed.

One honest cost recorded in the ADR: `src/adapters/react/` imports engine internals directly rather than through `src/index.ts`, so the public surface isn't what the adapter proves. Fine while the package is `private: true`; worth fixing if it's ever published.

## Test by hand

`pnpm --filter @mentis/engine dev` → **http://localhost:5180/react.html**

Type `@al`, arrow around, Enter to insert. Then compare with `/index.html` — same engine, same behaviour, different framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
